### PR TITLE
Proposal to introduce SUPPRESS_UNPARSED build flag to suppress MQTT messages being published for unparsed signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ MEMORY_DEBUG				; display heap usage information
 RAW_SIGNAL_DEBUG			; display raw received messages
 RSSI						; Enable collection of per pulse RSSI Values during signal reception
 RTL_DEBUG					; Enable RTL_433 Verbose option ( 0=normal, 1=verbose, 2=verbose decoders, 3=debug decoders, 4=trace decoding. )
-SUPPRESS_UNPARSED			; Enable supression of publishing MQTT messages for unparsed signals, e.g. model":"unknown","protocol":"signal parsing failed","duration"
+SUPPRESS_UNPARSED			; Enable supression of publishing MQTT messages for unparsed signals, e.g. {model":"unknown","protocol":"signal parsing failed"…
 ```
 
 ## Porting approach

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ MEMORY_DEBUG				; display heap usage information
 RAW_SIGNAL_DEBUG			; display raw received messages
 RSSI						; Enable collection of per pulse RSSI Values during signal reception
 RTL_DEBUG					; Enable RTL_433 Verbose option ( 0=normal, 1=verbose, 2=verbose decoders, 3=debug decoders, 4=trace decoding. )
+SUPPRESS_UNPARSED			; Enable supression of publishing MQTT messages for unparsed signals, e.g. model":"unknown","protocol":"signal parsing failed","duration"
 ```
 
 ## Porting approach
@@ -206,6 +207,7 @@ Build definitions
 ;  '-DDEMOD_DEBUG=true'
 ; '-DRTL_DEBUG=4'           ; rtl_433 verbose mode
 ;  '-DRAW_SIGNAL_DEBUG=true'
+;  '-DSUPPRESS_UNPARSED=true'
   '-DRF_EMITTER_GPIO=2'
   '-DRF_RECEIVER_GPIO=4'
 ;  '-DMY_DEVICES=true'

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ MEMORY_DEBUG				; display heap usage information
 RAW_SIGNAL_DEBUG			; display raw received messages
 RSSI						; Enable collection of per pulse RSSI Values during signal reception
 RTL_DEBUG					; Enable RTL_433 Verbose option ( 0=normal, 1=verbose, 2=verbose decoders, 3=debug decoders, 4=trace decoding. )
-SUPPRESS_UNPARSED			; Enable supression of publishing MQTT messages for unparsed signals, e.g. {model":"unknown","protocol":"signal parsing failed"…
+SUPPRESS_UNPARSED			; Enable suppression of publishing MQTT messages for unparsed signals, e.g. {model":"unknown","protocol":"signal parsing failed"…
 ```
 
 ## Porting approach

--- a/src/rtl_433_ESP.cpp
+++ b/src/rtl_433_ESP.cpp
@@ -439,6 +439,7 @@ void rtl_433_ESP::loop()
 #ifdef DEMOD_DEBUG
       logprintfLn(LOG_INFO, "# of messages decoded %d", events);
 #endif
+#ifdef PUBLISH_UNPARSED
       if (events == 0)
       {
         alogprintfLn(LOG_INFO, " ");
@@ -485,6 +486,7 @@ void rtl_433_ESP::loop()
       }
 
       // free(rtl_pulses);
+#endif
 #ifdef MEMORY_DEBUG
       logprintfLn(LOG_INFO, "Signal processing time: %lu", micros() - signalProcessingStart);
       logprintfLn(LOG_INFO, "Post run_ook_demods memory %d", ESP.getFreeHeap());

--- a/src/rtl_433_ESP.h
+++ b/src/rtl_433_ESP.h
@@ -31,6 +31,10 @@
 #define MINRSSI -82 // DB above noise level
 #endif
 
+#ifndef SUPPRESS_UNPARSED
+#define PUBLISH_UNPARSED
+#endif
+
 #define RECEIVER_BUFFER_SIZE 2 // Pulse train buffer count
 // #define MAXPULSESTREAMLENGTH 750 // Pulse train buffer size
 #define MINIMUM_PULSE_LENGTH 50 // signals shorter than this are ignored in interupt handler


### PR DESCRIPTION
While testing my OMG 0.9.6 setup with an 868Mhz CC1101 I found that the MQTT broker constantly receives messages from my many Homematic devices, as unknown/signal parsing failed

> {"model":"unknown","protocol":"signal parsing failed","duration":72226,"signalRssi":-59,"pulses":146,"train":1,"messageCount":1,"_enabledReceiver":1,"receiveMode":0,"currentRssi":-90,"minimumRssi":-82}

etc.

Using a custom reduced definition for MY_DEVICES did help in bringing down these unrecognised messages a bit, but I thought it would be desirable to be able to completely suppress any unparsed signal from creating MQTT messages, so I came up with the following changes.

So setting the build_flag

> '-DSUPPRESS_UNPARSED=true'

all recognised but unparsed signals do not get published, reducing the MQTT load.

Maybe you think this might be helpful to be included in your great rtl_433 OMG implementation.

Thanks