### PR TITLE
TFA Drop 30.3233.01: reducing the number of bits to 65bits

### DIFF
--- a/src/rtl_433/devices/tfa_drop_30.3233.c
+++ b/src/rtl_433/devices/tfa_drop_30.3233.c
@@ -113,7 +113,7 @@ Afterwards, messages are sent every 45s.
 
 #include "decoder.h"
 
-#define TFA_DROP_BITLEN 66
+#define TFA_DROP_BITLEN 65
 #define TFA_DROP_STARTBYTE 0x3 /* Inverted already */
 #define TFA_DROP_MINREPEATS 2
 


### PR DESCRIPTION
My device only sents 65bits. As I understand the documentation we only know the meening of the first 64bits. maybe it would be even better to reduce the repetition check to 64bits.

Here are two example output of my device:

[...]

bitbuffer:: Number of rows: 6 
[00] {64} 0a f3 ba 05 f1 55 ff 38    : 00001010 11110011 10111010 00000101 11110001 01010101 11111111 00111000 
[01] {65} 3d 79 dd 02 f8 aa ff 9c 00 : 00111101 01111001 11011101 00000010 11111000 10101010 11111111 10011100 0
[02] {65} 3d 79 dd 02 f8 aa ff 9c 00 : 00111101 01111001 11011101 00000010 11111000 10101010 11111111 10011100 0
[03] {65} 3d 79 dd 02 f8 aa ff 9c 00 : 00111101 01111001 11011101 00000010 11111000 10101010 11111111 10011100 0
[04] {65} 3d 79 dd 02 f8 aa ff 9c 00 : 00111101 01111001 11011101 00000010 11111000 10101010 11111111 10011100 0
[05] {64} 3d 79 dd 02 f8 aa ff 9c    : 00111101 01111001 11011101 00000010 11111000 10101010 11111111 10011100 
tfa_drop_303233_decode row_index: 1 
rtl_433_ESP(6): data_output {"model":"TFA-Drop","id":883165,"battery_ok":1,"rain_mm":0.508,"mic":"CHECKSUM","protocol":"TFA Drop Rain Gauge 30.3233.01","rssi":-51,"duration":347000}
N: Received message : {"model":"TFA-Drop","id":883165,"battery_ok":1,"rain_mm":0.508,"mic":"CHECKSUM","protocol":"TFA Drop Rain Gauge 30.3233.01","rssi":-51,"duration":347000}
pulse_demod_pwm(): TFA Drop Rain Gauge 30.3233.01
bitbuffer:: Number of rows: 6 
[00] {64} 0a f3 ba 05 f1 55 ff 38 
[01] {65} 3d 79 dd 02 f8 aa ff 9c 00 
[02] {65} 3d 79 dd 02 f8 aa ff 9c 00 
[03] {65} 3d 79 dd 02 f8 aa ff 9c 00 
[04] {65} 3d 79 dd 02 f8 aa ff 9c 00 
[05] {64} 3d 79 dd 02 f8 aa ff 9c 
rtl_433_ESP(7): demod(5) - TFA pool temperature sensor

[...]

rtl_433_ESP(7): demod(6) - TFA Drop Rain Gauge 30.3233.01
bitbuffer:: Number of rows: 7 
[00] { 1} 00                         : 0
[01] {43} 41 3e 2a bf c5 00          : 01000001 00111110 00101010 10111111 11000101 000
[02] {65} 3d 79 dd 04 f8 aa ff 14 00 : 00111101 01111001 11011101 00000100 11111000 10101010 11111111 00010100 0
[03] {65} 3d 79 dd 04 f8 aa ff 14 00 : 00111101 01111001 11011101 00000100 11111000 10101010 11111111 00010100 0
[04] {65} 3d 79 dd 04 f8 aa ff 14 00 : 00111101 01111001 11011101 00000100 11111000 10101010 11111111 00010100 0
[05] {65} 3d 79 dd 04 f8 aa ff 14 00 : 00111101 01111001 11011101 00000100 11111000 10101010 11111111 00010100 0
[06] {64} 3d 79 dd 04 f8 aa ff 14    : 00111101 01111001 11011101 00000100 11111000 10101010 11111111 00010100 
tfa_drop_303233_decode row_index: 2 
rtl_433_ESP(6): data_output {"model":"TFA-Drop","id":883165,"battery_ok":1,"rain_mm":0.508,"mic":"CHECKSUM","protocol":"TFA Drop Rain Gauge 30.3233.01","rssi":-46,"duration":349000}
N: Received message : {"model":"TFA-Drop","id":883165,"battery_ok":1,"rain_mm":0.508,"mic":"CHECKSUM","protocol":"TFA Drop Rain Gauge 30.3233.01","rssi":-46,"duration":349000}
pulse_demod_pwm(): TFA Drop Rain Gauge 30.3233.01
bitbuffer:: Number of rows: 7 
[00] { 1} 00                         : 0
[01] {43} 41 3e 2a bf c5 00          : 01000001 00111110 00101010 10111111 11000101 000
[02] {65} 3d 79 dd 04 f8 aa ff 14 00 
[03] {65} 3d 79 dd 04 f8 aa ff 14 00 
[04] {65} 3d 79 dd 04 f8 aa ff 14 00 
[05] {65} 3d 79 dd 04 f8 aa ff 14 00 
[06] {64} 3d 79 dd 04 f8 aa ff 14 
rtl_433_ESP(7): demod(5) - TFA pool temperature sensor


(For my debugging I have added some extra output.)