### PR TITLE
Use `heap_caps_calloc()` to force use of MALLOC_CAP_INTERNAL memory.

### DIFF
--- a/src/rtl_433_ESP.cpp
+++ b/src/rtl_433_ESP.cpp
@@ -405,8 +405,8 @@ void rtl_433_ESP::loop() {
 #ifdef MEMORY_DEBUG
       logprintfLn(LOG_INFO, "Pre copy out of train: %d", ESP.getFreeHeap());
 #endif
-      pulse_data_t *rtl_pulses =
-          (pulse_data_t *)heap_caps_calloc(1, sizeof(pulse_data_t), MALLOC_CAP_INTERNAL);
+      pulse_data_t *rtl_pulses = (pulse_data_t *)heap_caps_calloc(
+          1, sizeof(pulse_data_t), MALLOC_CAP_INTERNAL);
       memcpy(rtl_pulses, (char *)&_pulseTrains[_receiveTrain],
              sizeof(pulse_data_t));
       _pulseTrains[_receiveTrain].num_pulses =
@@ -618,8 +618,8 @@ rtl_433_ESP::rtl_433_ESP(int8_t outputPin) {
     digitalWrite((uint8_t)_outputPin, LOW);
   }
 
-  _pulseTrains =
-      (pulse_data_t *)heap_caps_calloc(RECEIVER_BUFFER_SIZE, sizeof(pulse_data_t), MALLOC_CAP_INTERNAL);
+  _pulseTrains = (pulse_data_t *)heap_caps_calloc(
+      RECEIVER_BUFFER_SIZE, sizeof(pulse_data_t), MALLOC_CAP_INTERNAL);
 }
 
 void rtl_433_ESP::setRSSIThreshold(int newRssi) {

--- a/src/rtl_433_ESP.cpp
+++ b/src/rtl_433_ESP.cpp
@@ -406,7 +406,7 @@ void rtl_433_ESP::loop() {
       logprintfLn(LOG_INFO, "Pre copy out of train: %d", ESP.getFreeHeap());
 #endif
       pulse_data_t *rtl_pulses =
-          (pulse_data_t *)calloc(1, sizeof(pulse_data_t));
+          (pulse_data_t *)heap_caps_calloc(1, sizeof(pulse_data_t), MALLOC_CAP_INTERNAL);
       memcpy(rtl_pulses, (char *)&_pulseTrains[_receiveTrain],
              sizeof(pulse_data_t));
       _pulseTrains[_receiveTrain].num_pulses =
@@ -619,7 +619,7 @@ rtl_433_ESP::rtl_433_ESP(int8_t outputPin) {
   }
 
   _pulseTrains =
-      (pulse_data_t *)calloc(RECEIVER_BUFFER_SIZE, sizeof(pulse_data_t));
+      (pulse_data_t *)heap_caps_calloc(RECEIVER_BUFFER_SIZE, sizeof(pulse_data_t), MALLOC_CAP_INTERNAL);
 }
 
 void rtl_433_ESP::setRSSIThreshold(int newRssi) {


### PR DESCRIPTION
See https://github.com/NorthernMan54/rtl_433_ESP/issues/61