### PR TITLE
Fix memory leak in unit conversion

### DIFF
--- a/library.json
+++ b/library.json
@@ -14,5 +14,10 @@
     ],
     "dependencies": {
         "jgromes/RadioLib": "^5.3.0" 
+    },
+    "build": {
+        "flags":[
+            "-DMEMORY_DEBUG"
+        ]
     }
 }

--- a/library.json
+++ b/library.json
@@ -14,10 +14,5 @@
     ],
     "dependencies": {
         "jgromes/RadioLib": "^5.3.0" 
-    },
-    "build": {
-        "flags":[
-            "-DMEMORY_DEBUG"
-        ]
     }
 }

--- a/src/rtl_433/r_api.c
+++ b/src/rtl_433/r_api.c
@@ -798,10 +798,12 @@ void data_acquired_handler(r_device* r_dev, data_t* data) {
       else if ((d->type == DATA_DOUBLE) &&
                (str_endswith(d->key, "_in") || str_endswith(d->key, "_inch"))) {
         d->value.v_dbl = inch2mm(d->value.v_dbl);
-        char* new_label =
-            str_replace(str_replace(d->key, "_inch", "_in"), "_in", "_mm");
+        // str_replace allocates new memory, nesting creates leaks
+        char* new_label1 = str_replace(d->key, "_inch", "_in");
+        char* new_label2 = str_replace(new_label1, "_in", "_mm");
+        free(new_label1);
         free(d->key);
-        d->key = new_label;
+        d->key = new_label2;
         char* new_format_label = str_replace(d->format, "in", "mm");
         free(d->format);
         d->format = new_format_label;

--- a/src/rtl_433/r_api.c
+++ b/src/rtl_433/r_api.c
@@ -798,7 +798,7 @@ void data_acquired_handler(r_device* r_dev, data_t* data) {
       else if ((d->type == DATA_DOUBLE) &&
                (str_endswith(d->key, "_in") || str_endswith(d->key, "_inch"))) {
         d->value.v_dbl = inch2mm(d->value.v_dbl);
-        // str_replace allocates new memory, nesting creates leaks
+        // need to free ptr returned from str_replace
         char* new_label1 = str_replace(d->key, "_inch", "_in");
         char* new_label2 = str_replace(new_label1, "_in", "_mm");
         free(new_label1);


### PR DESCRIPTION
## :recycle: Current situation

A memory leak exists converting inches to millimeters. It is related to an issue created in OpenMQTTGateway: https://github.com/1technophile/OpenMQTTGateway/issues/1693

## :bulb: Proposed solution

Avoid nesting calls to `str_replace`, to allow allocated memory to be properly freed.

## :gear: Release Notes

N/A
