### PR TITLE
Add Support for ESP32-C3 e S3

### DIFF
--- a/src/rtl_433_ESP.cpp
+++ b/src/rtl_433_ESP.cpp
@@ -32,7 +32,11 @@
 #if defined(RF_MODULE_SCK) && defined(RF_MODULE_MISO) && \
     defined(RF_MODULE_MOSI) && defined(RF_MODULE_CS)
 #  include <SPI.h>
+#  if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
+SPIClass newSPI(FSPI);
+#  elif CONFIG_IDF_TARGET_ESP32
 SPIClass newSPI(VSPI);
+#  endif
 #endif
 
 #ifdef RF_SX1276

--- a/src/rtl_433_ESP.cpp
+++ b/src/rtl_433_ESP.cpp
@@ -34,7 +34,7 @@
 #  include <SPI.h>
 #  if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S3
 SPIClass newSPI(FSPI);
-#  elif CONFIG_IDF_TARGET_ESP32
+#  else
 SPIClass newSPI(VSPI);
 #  endif
 #endif


### PR DESCRIPTION
## :recycle: Current situation

ESP32-C3 and ESP32-S3 on Arduino-ESP32-Core has first free SPI ( SPI2 ) mapped as FSPI and not VSPI
## :bulb: Proposed solution

Added check on CONFIG_IDF_TARGET_ESP32C3 and CONFIG_IDF_TARGET_ESP32S3 to set FSPI and not VSPI as SPI port.

## :gear: Release Notes

None

## :heavy_plus_sign: Additional Information

None

### Testing

Compile and works on an ESP32-C3 Supermini

### Reviewer Nudging

N/A
