### PR TITLE
Add support for ESP32-C3 "contracted" with cc1101

### DIFF
--- a/example/OOK_Receiver/platformio.ini
+++ b/example/OOK_Receiver/platformio.ini
@@ -10,6 +10,7 @@
 
 [platformio]
 default_envs = esp32_lilygo
+;default_envs = esp32c3_cdc_cc1101
 src_dir = .
 
 [libraries]
@@ -27,6 +28,47 @@ lib_deps =
 	${libraries.arduinolog}
 	${libraries.arduinojson}
   ${libraries.rtl_433_ESP}
+
+[env:esp32c3_cdc_cc1101]
+platform = espressif32
+board = airm2m_core_esp32c3
+build_flags =
+  '-DCONFIG_ESP_CONSOLE_UART=1'	; settings for esp32c3 without uart
+  '-DARDUINO_USB_MODE=1'
+  '-DARDUINO_USB_CDC_ON_BOOT=1'
+  '-DLOG_LEVEL=LOG_LEVEL_TRACE'
+  '-DONBOARD_LED=13'           ; LED_D4
+; *** rtl_433_ESP Options ***
+;  '-DRF_MODULE_FREQUENCY=915.00'
+  '-DOOK_MODULATION=true'      ; False is FSK, True is OOK
+  '-DRTL_DEBUG=4'              ; rtl_433 verbose mode
+;  '-DRTL_VERBOSE=58'          ; LaCrosse TX141-Bv2, TX141TH-Bv2, TX141-Bv3, TX141W, TX145wsdth sensor
+;  '-DRAW_SIGNAL_DEBUG=true'   ; display raw received messages
+;  '-DMEMORY_DEBUG=true'   ; display memory usage information
+  '-DDEMOD_DEBUG=true'  ; display signal debug info
+	'-DMY_DEVICES=true'		; subset of devices
+;  '-DPUBLISH_UNPARSED=true'   ; publish unparsed signal details
+  '-DMINRSSI=-82'
+;  '-DRSSI_THRESHOLD=12'         ; Apply a delta of 12 to average RSSI level
+;  '-DAVERAGE_RSSI=5000'     ; Display RSSI floor ( Average of 5000 samples )
+;  '-DSIGNAL_RSSI=true'             ; Display during signal receive
+;  '-DOOK_MODULATION=false'       ; False is FSK, True is OOK
+; *** RF Module Options ***
+  '-DRF_CC1101="CC1101"'  ; CC1101 Transceiver Module
+;  '-DRF_MODULE_CS=7'      ; pin to be used as chip select
+  '-DRF_MODULE_GDO0=11'   ; CC1101 pin GDO0
+  '-DRF_MODULE_GDO2=6'    ; CC1101 pin GDO2
+  '-DRF_MODULE_INIT_STATUS=true'    ; Display transceiver config during startup
+; *** RadioLib Options ***
+;  '-DRADIOLIB_DEBUG=true'
+;  '-DRADIOLIB_VERBOSE=true'
+; *** FSK Setting Testing ***
+;  '-DsetBitrate'
+;  '-DsetFreqDev'
+;  '-DsetRxBW'
+
+upload_protocol = esptool
+monitor_speed = 921600
 
 [env:esp32_cc1101]
 board = esp32dev


### PR DESCRIPTION
This adds support for the Luatos ESP32C3-CORE Development Board, and clones, wired with a CC1101 rf module.

The esp32c3 is using the native USB interface for serial console and firmware updates, so should run on "contracted" boards without an extra usb2serial chip.

The GDO0 and GDO2 pins are configured at IO11 and IO06 of the mcu.

Example execution command:
    pio run -e esp32c3_cdc_cc1101 -t upload -t monitor


![luatos_esp32c3](https://github.com/NorthernMan54/rtl_433_ESP/assets/4540127/9d864d2e-c032-49b9-86be-7d2e15ec2f3e)
