### PR TITLE
Update signalDecoder.cpp: Fix OOM crash caused by rtl_433_Decoder_Stack too small on Lilygo Lora device

### DIFF
--- a/src/signalDecoder.cpp
+++ b/src/signalDecoder.cpp
@@ -27,15 +27,17 @@
 
 /*----------------------------- rtl_433_ESP Internals -----------------------------*/
 
-#if defined(RTL_ANALYZER) || defined(RTL_ANALYZE)
-#  define rtl_433_Decoder_Stack 60000
-#elif defined(RTL_VERBOSE) || defined(RTL_DEBUG)
-#  define rtl_433_Decoder_Stack 30000
-#else
-#  if OOK_MODULATION
-#    define rtl_433_Decoder_Stack 10000
+#ifndef rtl_433_Decoder_Stack
+#  if defined(RTL_ANALYZER) || defined(RTL_ANALYZE)
+#    define rtl_433_Decoder_Stack 60000
+#  elif defined(RTL_VERBOSE) || defined(RTL_DEBUG)
+#    define rtl_433_Decoder_Stack 30000
 #  else
-#    define rtl_433_Decoder_Stack 20000
+#    if OOK_MODULATION
+#      define rtl_433_Decoder_Stack 11500
+#    else
+#      define rtl_433_Decoder_Stack 20000
+#    endif
 #  endif
 #endif
 


### PR DESCRIPTION
## :recycle: Current situation

This fixes the crash caused by OOM when low water mark on rtl_433_Decder_Stack drops below 0. (See: https://github.com/1technophile/OpenMQTTGateway/issues/2043) 

*Describe the current situation. Explain current problems, if there are any. Be as descriptive as possible (e.g., including examples or code snippets).*

## :bulb: Proposed solution

 I increased the memory size by 1500 which after running for a week on 2 different Lilygo Lora ESP32 devices leaves the water mark at just over 1KB -- I want to leave a little spare in case there are other sensor configurations and edge cases that would dip further into the stack.

I also wrapped the definitions of `rtl_433_Decoder_stack` with `ifndef rtl_433_Decoder_Stack` so that users can easily manually tweak the allocated stack size for their own particular situations.

## :gear: Release Notes

*Increase `rtl_433_Decoder_Stack` size for OOK_Modulation to avoid OOM crashes*


### Testing

*NA*

### Reviewer Nudging

*Where should the reviewer start? what is a good entry point?*
