### PR TITLE
rename silvercrest and nexus to mitigate codebase conflict with ESPiL…

### DIFF
--- a/include/rtl_433_devices.h
+++ b/include/rtl_433_devices.h
@@ -157,7 +157,7 @@
     DECL(new_template)               \
     DECL(newkaku)                    \
     DECL(nexa)                       \
-    DECL(nexus)                      \
+    DECL(RTLnexus)                      \
     DECL(nice_flor_s)                \
     DECL(norgo)                      \
     DECL(oil_smart)                  \
@@ -192,7 +192,7 @@
     DECL(scmplus)                    \
     DECL(secplus_v1)                 \
     DECL(sharp_spc775)               \
-    DECL(silvercrest)                \
+    DECL(RTLsilvercrest)                \
     DECL(ss_sensor)                  \
     DECL(simplisafe_gen3)            \
     DECL(skylink_motion)             \

--- a/src/rtl_433/devices/RTLnexus.c
+++ b/src/rtl_433/devices/RTLnexus.c
@@ -112,7 +112,7 @@ static char const *const output_fields[] = {
         NULL,
 };
 
-r_device const nexus = {
+r_device const RTLnexus = {
         .name        = "Nexus, FreeTec NC-7345, NX-3980, Solight TE82S, TFA 30.3209 temperature/humidity sensor",
         .modulation  = OOK_PULSE_PPM,
         .short_width = 1000,

--- a/src/rtl_433/devices/RTLsilvercrest.c
+++ b/src/rtl_433/devices/RTLsilvercrest.c
@@ -55,7 +55,7 @@ static char const *const output_fields[] = {
         NULL,
 };
 
-r_device const silvercrest = {
+r_device const RTLsilvercrest = {
         .name        = "Silvercrest Remote Control",
         .modulation  = OOK_PULSE_PWM,
         .short_width = 264,

--- a/src/signalDecoder.cpp
+++ b/src/signalDecoder.cpp
@@ -182,7 +182,7 @@ void rtlSetup() {
       memcpy(&cfg->devices[93], &new_template, sizeof(r_device));
       memcpy(&cfg->devices[94], &newkaku, sizeof(r_device));
       memcpy(&cfg->devices[95], &nexa, sizeof(r_device));
-      memcpy(&cfg->devices[96], &nexus, sizeof(r_device));
+      memcpy(&cfg->devices[96], &RTLnexus, sizeof(r_device));
       memcpy(&cfg->devices[97], &nice_flor_s, sizeof(r_device));
       memcpy(&cfg->devices[98], &norgo, sizeof(r_device));
       memcpy(&cfg->devices[99], &oil_standard_ask, sizeof(r_device));
@@ -211,7 +211,7 @@ void rtlSetup() {
       memcpy(&cfg->devices[122], &schrader_SMD3MA4, sizeof(r_device));
       memcpy(&cfg->devices[123], &scmplus, sizeof(r_device));
       memcpy(&cfg->devices[124], &secplus_v1, sizeof(r_device));
-      memcpy(&cfg->devices[125], &silvercrest, sizeof(r_device));
+      memcpy(&cfg->devices[125], &RTLsilvercrest, sizeof(r_device));
       memcpy(&cfg->devices[126], &ss_sensor, sizeof(r_device));
       memcpy(&cfg->devices[127], &skylink_motion, sizeof(r_device));
       memcpy(&cfg->devices[128], &smoke_gs558, sizeof(r_device));

--- a/tools/decoder.fragment
+++ b/tools/decoder.fragment
@@ -97,7 +97,7 @@ if (rtl_433_ESP::ookModulation) {
   memcpy(&cfg->devices[93], &new_template, sizeof(r_device));
   memcpy(&cfg->devices[94], &newkaku, sizeof(r_device));
   memcpy(&cfg->devices[95], &nexa, sizeof(r_device));
-  memcpy(&cfg->devices[96], &nexus, sizeof(r_device));
+  memcpy(&cfg->devices[96], &RTLnexus, sizeof(r_device));
   memcpy(&cfg->devices[97], &nice_flor_s, sizeof(r_device));
   memcpy(&cfg->devices[98], &norgo, sizeof(r_device));
   memcpy(&cfg->devices[99], &oil_standard_ask, sizeof(r_device));
@@ -126,7 +126,7 @@ if (rtl_433_ESP::ookModulation) {
   memcpy(&cfg->devices[122], &schrader_SMD3MA4, sizeof(r_device));
   memcpy(&cfg->devices[123], &scmplus, sizeof(r_device));
   memcpy(&cfg->devices[124], &secplus_v1, sizeof(r_device));
-  memcpy(&cfg->devices[125], &silvercrest, sizeof(r_device));
+  memcpy(&cfg->devices[125], &RTLsilvercrest, sizeof(r_device));
   memcpy(&cfg->devices[126], &ss_sensor, sizeof(r_device));
   memcpy(&cfg->devices[127], &skylink_motion, sizeof(r_device));
   memcpy(&cfg->devices[128], &smoke_gs558, sizeof(r_device));

--- a/tools/rtl_433_devices.fragment
+++ b/tools/rtl_433_devices.fragment
@@ -146,7 +146,7 @@
   DECL(new_template) \
   DECL(newkaku) \
   DECL(nexa) \
-  DECL(nexus) \
+  DECL(RTLnexus) \
   DECL(nice_flor_s) \
   DECL(norgo) \
   DECL(oil_smart) \
@@ -181,7 +181,7 @@
   DECL(scmplus) \
   DECL(secplus_v1) \
   DECL(sharp_spc775) \
-  DECL(silvercrest) \
+  DECL(RTLsilvercrest) \
   DECL(ss_sensor) \
   DECL(simplisafe_gen3) \
   DECL(skylink_motion) \


### PR DESCRIPTION
Hit the problem with codebase conflict, then saw the remark in the README.
With this change openmqttgateway compiles without warning. However i am not confident the changes are functional ok. What is your opinion?