### PR TITLE
Fix three small correctness issues: unsigned pin sentinel, signalRatio arithmetic, mislabelled register

### DIFF
--- a/src/rtl_433_ESP.cpp
+++ b/src/rtl_433_ESP.cpp
@@ -927,7 +927,7 @@ void rtl_433_ESP::getModuleStatus() {
   alogprintfLn(LOG_INFO, "RegOpMode: 0x%.2x",
                _mod->SPIreadRegister(RADIOLIB_SX127X_REG_OP_MODE));
   alogprintfLn(LOG_INFO, "RegPacketConfig1: 0x%.2x",
-               _mod->SPIreadRegister(RADIOLIB_SX127X_REG_PACKET_CONFIG_2));
+               _mod->SPIreadRegister(RADIOLIB_SX127X_REG_PACKET_CONFIG_1));
   alogprintfLn(LOG_INFO, "RegPacketConfig2: 0x%.2x",
                _mod->SPIreadRegister(RADIOLIB_SX127X_REG_PACKET_CONFIG_2));
   alogprintfLn(LOG_INFO, "RegBitrateMsb: 0x%.2x",

--- a/src/rtl_433_ESP.cpp
+++ b/src/rtl_433_ESP.cpp
@@ -517,7 +517,9 @@ void rtl_433_ESP::loop() {
       }
 #  endif
 #endif
-      signalRatio = (totalSignals - (ignoredSignals + unparsedSignals)) / totalSignals * 100;
+      signalRatio = totalSignals
+                        ? (100 * (totalSignals - (ignoredSignals + unparsedSignals))) / totalSignals
+                        : 0;
 
       totalSignals = 0;
       ignoredSignals = 0;

--- a/src/rtl_433_ESP.cpp
+++ b/src/rtl_433_ESP.cpp
@@ -123,7 +123,7 @@ unsigned long _deafWorkaround = millis();
 #endif
 
 int16_t rtl_433_ESP::_interrupt = NOT_AN_INTERRUPT;
-static byte receiverGpio = -1;
+static int8_t receiverGpio = -1;
 
 static TaskHandle_t rtl_433_ReceiverHandle;
 


### PR DESCRIPTION
Three unrelated one-line fixes, one per commit so any can be dropped
independently.

### 1. `receiverGpio` sentinel is unsigned, so its guard can never fail

```c
static byte receiverGpio = -1;   // :126
if (receiverGpio >= 0) {         // :425 — always true
```

`byte` is `unsigned char`, so `-1` is stored as `255` and the guard is
tautological. A board whose pin macro resolves to `-1` calls
`attachInterrupt(255, ...)`, which does nothing, and the gateway then runs
indefinitely with a receiver that can never fire. `int8_t` keeps the sentinel
meaningful and still covers every valid pin.

### 2. `signalRatio` truncates to 0 before the multiply

```c
signalRatio = (totalSignals - (ignoredSignals + unparsedSignals)) / totalSignals * 100;   // :520
```

Integer division runs before the `* 100`, so the result is `0` in every case
except a perfect run, where it is `100`. Multiplying first gives the intended
percentage; the change also guards `totalSignals == 0`, reachable on a quiet
band. Statistic only — it does not affect reception.

### 3. Status dump prints `PACKET_CONFIG_2` under the `RegPacketConfig1` label

```c
alogprintfLn(LOG_INFO, "RegPacketConfig1: 0x%.2x",
             _mod->SPIreadRegister(RADIOLIB_SX127X_REG_PACKET_CONFIG_2));   // :927
```

Both lines read `PACKET_CONFIG_2`, so the value labelled `RegPacketConfig1` was
never that register. On an SX1278 the line reported `0x00` before and `0x80`
after.

## Testing

- Built for `heltec_wifi_lora_32_V2` (SX1278, 433.920 OOK) with this branch in
  isolation against `main`.
- Fix 3 verified on hardware. Fixes 1 and 2 are inspection only — neither is
  reproduced here.