### PR TITLE
Final Vivint Tuning Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,7 @@ method and results are recorded in
 
 ```ini
 build_flags =
+  -DRF_MODULE_FREQUENCY=345.00
   -DCC1101_RX_BANDWIDTH=162.5
   -DCC1101_AGCCTRL2=0x84
   -DCC1101_AGCCTRL1=0x40

--- a/docs/CC1101_43392_TUNING_RESULTS.md
+++ b/docs/CC1101_43392_TUNING_RESULTS.md
@@ -133,7 +133,7 @@ This passband boundary suggests that this particular sensor's carrier is above
 nominal, approximately 433.98 MHz. Moving the CC1101 center upward did not
 produce a better capture rate than 433.920 MHz.
 
-### Matrix limitation
+### Initial matrix limitation and rerun
 
 The RTL-SDR reference became unreliable during the matrix run. It recorded only
 6 target events while the CC1101 recorded 117, compared with 72 RTL-SDR events
@@ -141,10 +141,14 @@ in the preceding 20-minute A/B test. Restarting rtl_433 and moving the RTL-SDR
 center frequency did not restore its normal event cadence.
 
 The sensor continued transmitting at a stable interval of approximately 16.25
-seconds, as observed by the CC1101 at passing settings. The matrix is therefore
-useful for locating the CC1101 passband boundary, but it is not a valid
+seconds, as observed by the CC1101 at passing settings. The initial matrix is
+therefore useful for locating the CC1101 passband boundary, but it is not a valid
 RTL-SDR-reference-scored sensitivity comparison. It must not be used to claim
 that one of the passing matrix cells has greater range than another.
+
+The test was subsequently rerun. The rerun did not demonstrate an improvement
+that justified changing the fixed recommendation. It remains 433.920 MHz /
+203.125 kHz / `0xC7` / `0x40` / `0x93`.
 
 ## Interpretation
 
@@ -185,4 +189,3 @@ must maintain a verified event cadence throughout the run.
 - Reference comparison harness: `tools/cc1101_reference_test.py`
 - Tuning firmware: `examples/cc1101_tuning/cc1101_tuning.ino`
 - Tuning environments: `examples/cc1101_tuning/platformio.ini`
-

--- a/docs/CC1101_VIVINT_TUNING_RESULTS.md
+++ b/docs/CC1101_VIVINT_TUNING_RESULTS.md
@@ -15,10 +15,12 @@ candidate:
 -DCC1101_AGCCTRL0=0xA0
 ```
 
-Across 56 five-minute windows per profile, this profile produced 6,080 decoded
-messages versus 5,221 for the extended candidate. It won 53 paired windows,
-lost two, and tied one. It remains the recommended starting point for the
-tested installation.
+The earlier `0x84` profile produced 6,080 decoded messages versus 5,221 for the
+extended candidate across 56 five-minute windows per profile. A later test that
+counted duplicate burst repeats favored `0x86`, but production counter skips
+showed that repeat yield was the wrong primary metric. A counter-continuity
+retest found zero gaps with `0x84` and `0x85`, while `0x86` lost 16 counters in
+two windows. The recommendation therefore remains `0x84`.
 
 ## Test method
 
@@ -35,8 +37,157 @@ tested installation.
   changing propagation or interference conditions.
 
 The firmware also recorded raw signals, decoder signals, zero-decode outcomes,
-callback messages, RSSI summaries, and mean pulse counts. These were useful
-diagnostics, but decoded-message count was the selection criterion.
+callback messages, RSSI summaries, and mean pulse counts. Later production-style
+tests used unique Vivint counter continuity as the primary score: duplicate
+repeats counted once and skipped counter values indicated a completely missed
+transmission.
+
+## Antenna tuning
+
+### Reference dimensions and feed point
+
+The free-space wavelength at 345 MHz is approximately 869 mm (34.2 inches), so
+a theoretical quarter-wave monopole is approximately 217 mm (8.55 inches).
+That value is a starting point, not a guaranteed installed resonant length.
+The connector, receiver ground plane, wire diameter, enclosure, nearby wiring,
+and surrounding objects all contribute to the antenna system and can shift its
+resonance.
+
+A straight whip should be measured along the conductive path from the point
+where the connector center conductor joins the radiating element to the tip.
+The connector's grounded outer shell is not part of that measurement. The
+antenna used here has a slotted metal barrel approximately 1/4 inch long on the
+coil side. It was not established how much of that barrel is electrically part
+of the center-fed radiator, so quoted physical lengths should state whether the
+barrel is included. This uncertainty is significant compared with the 1/4-inch
+difference between the two whips tested below.
+
+### Supplied spring antenna
+
+The CC1101 receiver was supplied with a spring antenna believed to be intended
+for the commonly used 433 MHz band. The spring was wound on approximately a
+9/64-inch (3.57 mm) diameter, determined by inserting a snug drill bit. When
+unwound, its conductor measured approximately 12 inches.
+
+The 12-inch conductor length must not be compared directly with the 8.55-inch
+quarter-wave dimension. In the spring form, distributed inductance,
+turn-to-turn capacitance, pitch, wire diameter, straight lead length, connector,
+and PCB ground plane determine resonance. The spring is therefore an
+electrically shortened antenna, rather than a 12-inch straight whip folded into
+a mechanically convenient shape.
+
+Moving a nominal 433 MHz spring design toward 345 MHz requires making it
+electrically longer. The frequency ratio, 433/345, is approximately 1.255, so a
+fully geometrically scaled design would be about 25.5% larger. That ratio is
+useful only as an initial estimate: adding turns, compressing turns, or adding a
+straight section does not scale every distributed property equally. Trimming
+the spring would normally move its resonance upward, away from 345 MHz.
+Accurate adjustment of the coiled form requires a VNA measurement at the feed
+point with the antenna installed over a representative receiver ground plane.
+
+For this receive-only experiment, converting the available conductor into a
+straight quarter-wave whip provided a simpler, reproducible starting point.
+The wire should initially be left slightly long and shortened in small steps
+only after comparative testing or a VNA measurement. Folding back the excess
+is reversible but still changes the antenna electrically, so it is not an
+exact substitute for testing the final cut length.
+
+### Installed comparison and interpretation
+
+Two receivers named `north` and `south` were operated concurrently, side by
+side. These names identify the devices and do not describe their test positions
+or signal directions. The original tuned `north` device used an antenna
+approximately 8 1/2 inches long, while the new `south` device used an antenna
+approximately 8 3/4 inches long. Both receive-only installations produced about
+the same observed performance at 345 MHz.
+
+In isolation, an ideal 8.5-inch quarter wave corresponds to approximately
+347 MHz and an ideal 8.75-inch quarter wave to approximately 337 MHz. Real
+installed resonance cannot be inferred from those calculations because of the
+feed-point and ground-plane effects described above. The 1/4-inch length
+difference is only about 3%, and reception is normally broad enough that a
+clear difference may not appear when the received signal has ample margin.
+
+The present observation supports the limited conclusion that neither antenna
+has demonstrated a practical advantage in its current position. It does not
+show that both antennas are equally resonant or that 8.5 and 8.75 inches are
+universally equivalent. Receiver sensitivity and construction remain
+confounded with antenna length, while orientation, multipath, interference,
+and transmitter distance can also obscure small differences.
+
+A stronger follow-up test would use unique Vivint counters and median RSSI over
+many transmissions, then swap the antennas between the two side-by-side
+receivers. Testing at the weakest reliably received transmitter location will
+expose differences that a strong signal can conceal. Until such a crossover
+test or VNA sweep shows otherwise, 8.5 inches is a defensible nominal 345 MHz
+length and there is no measured reason to shorten the 8.75-inch antenna.
+
+Any cutting, coiling, feed-line rerouting, enclosure change, or antenna
+repositioning can change reception and should be followed by a new controlled
+comparison. The RF profile results in this document apply to the antenna and
+installation used during each test; antenna changes can justify repeating the
+receiver-profile validation.
+
+## Receiver profile retesting after the antenna change
+
+### Post-trim retest result
+
+After trimming the antenna, a fresh sweep initially selected a combined
+345.10 MHz / 203.125 kHz / `0xC7` / `0x40` / `0x90` candidate. A direct
+alternating comparison rejected that combination: the released profile
+produced 333 decoded messages across four windows versus 159 for the candidate.
+
+Follow-up A/B tests changed one setting at a time while holding the released
+profile constant:
+
+| Isolated setting | Released value | Candidate value | Result |
+| --- | ---: | ---: | --- |
+| Frequency | 345.00 MHz | 345.10 MHz | 79 versus 0 decoded messages; retain 345.00 MHz |
+| Bandwidth | 162.5 kHz | 203.125 kHz | 166 versus 96 after two cycles; retain 162.5 kHz |
+| `AGCCTRL2` | `0x84` | `0xC7` | 167 versus 46 after two cycles; retain `0x84` |
+| `AGCCTRL0` | `0xA0` | `0x90` | 346 versus 350 after four cycles; no meaningful decode-yield difference |
+
+Because decoded-message count is the primary score, the four-message
+`AGCCTRL0` difference is treated as a tie rather than evidence for changing
+the shipping profile. The post-trim retest therefore leaves the existing
+recommendation unchanged.
+
+### Final narrow exploration
+
+A final sweep tested frequency from 344.97 through 345.03 MHz, adjacent valid
+CC1101 bandwidths, `AGCCTRL2` values `0x82` through `0x86`, both AGC carrier
+sense modes, and three AGC wait times. Sequential winners were treated only as
+candidates and then checked with directly alternating A/B windows.
+
+The combined `345.02 / 162.5 / 0x86 / 0x40 / 0x90` candidate produced 214
+decoded messages versus 120 for the released profile across two complete A/B
+cycles. Follow-up tests attributed the useful change to `AGCCTRL2`:
+
+| Isolated test | Result | Decision |
+| --- | ---: | --- |
+| `AGCCTRL2` `0x84` vs `0x86` | 130 vs 228 decoded; 106 vs 18 failures | Use `0x86` |
+| 345.00 vs 345.02 MHz with `0x86` | 444 vs 442 decoded; 20 vs 30 failures | Keep 345.00 MHz |
+| `AGCCTRL0` `0x90`, `0xA0`, `0xB0` sequential check | 112, 110, 111 decoded | Keep `0xA0` |
+| 135.417, 162.5, 203.125 kHz | 39, 73, 45 decoded | Keep 162.5 kHz |
+
+This result demonstrates why decoded-repeat totals alone are not sufficient.
+The counter-continuity validation below supersedes its `0x86` conclusion.
+
+### Production-style counter-continuity validation
+
+Ten-minute alternating windows counted each Vivint counter once, regardless of
+how many copies of its burst decoded. The key results were:
+
+| Isolated test | Counter-continuity result | Decision |
+| --- | --- | --- |
+| `AGCCTRL2` `0x84` / `0x85` / `0x86` | `0x84`: 57 unique, 0 gaps; `0x85`: 58 unique, 0 gaps; `0x86`: 21 unique, 16 gaps | Keep conservative `0x84` |
+| Bandwidth 135.417 / 162.5 / 203.125 / 232.143 kHz | 34/0, 39/0, 38/3, 39/0 unique/gaps | Keep narrower 162.5 kHz |
+| AGC wait `0x80` / `0x90` / `0xA0` / `0xB0` | Longer three values were effectively tied and gap-free | Keep `0xA0` |
+| AGC filter `0xA0` / `0xA1` / `0xA2` / `0xA3` | `0xA1` halved repeat margin; `0xA2`/`0xA3` nearly eliminated Vivint decodes | Keep `0xA0` |
+| AGC hysteresis `0x20` / `0x60` / `0xA0` / `0xE0` | `0xA0` led with 41 unique counters; `0xE0` reduced repeat margin | Keep `0xA0` |
+
+For the tested receiver, antenna, transmitter, and RF environment, the final
+recommendation is `345.00 MHz / 162.5 kHz / 0x84 / 0x40 / 0xA0`.
 
 ## Profiles
 
@@ -125,4 +276,3 @@ platformio device monitor -e esp32_cc1101_vivint_original_profile_compare
 
 See `examples/cc1101_tuning/README.md` for suite durations and configuration.
 No reflashing is required while a suite advances through its settings.
-

--- a/examples/OOK_Receiver/OOK_Receiver.ino
+++ b/examples/OOK_Receiver/OOK_Receiver.ino
@@ -91,18 +91,18 @@ enum CC1101TuningPhase : uint8_t {
 // receive bandwidth and AGC registers.
 const CC1101TuningSetting profileValues[] = {
 #    if defined(CC1101_OOK_ORIGINAL_PROFILE_COMPARE)
-    // Original documented Vivint recommendation versus the extended-suite
-    // winner selected by the long alternating comparison.
+    // Released Vivint recommendation versus the extended-suite candidate
+    // rejected by the final long alternating comparison.
     {345.00f, 162.5f, 0x84, 0x40, 0xA0},
     {345.12f, 325.0f, 0xC1, 0x00, 0x61},
 #    elif defined(CC1101_OOK_EXTENDED_PROFILE_COMPARE)
-    // Current recommendation versus the complete winner assembled by the
-    // extended characterization suite.
+    // Intermediate candidate versus the candidate assembled by the extended
+    // characterization suite.
     {345.10f, 270.833f, 0x83, 0x40, 0x90},
     {345.12f, 325.0f, 0xC1, 0x00, 0x61},
 #    elif defined(CC1101_OOK_AGC2_COMPARE)
     // Direct Vivint comparison of the clean 30 dB magnitude-target result
-    // against the current 33 dB candidate. All other settings remain fixed.
+    // against the intermediate 33 dB candidate. All other settings remain fixed.
     {345.10f, 270.833f, 0x82, 0x40, 0x90},
     {345.10f, 270.833f, 0x83, 0x40, 0x90},
 #    else
@@ -113,7 +113,7 @@ const CC1101TuningSetting profileValues[] = {
 #    endif
 };
 #    if defined(CC1101_OOK_ORIGINAL_PROFILE_COMPARE)
-const char* const profileNames[] = {"original", "new_recommendation"};
+const char* const profileNames[] = {"released_profile", "extended_candidate"};
 #    elif defined(CC1101_OOK_EXTENDED_PROFILE_COMPARE)
 const char* const profileNames[] = {"current", "extended_winner"};
 #    elif defined(CC1101_OOK_AGC2_COMPARE)

--- a/examples/OOK_Receiver/platformio.ini
+++ b/examples/OOK_Receiver/platformio.ini
@@ -206,10 +206,10 @@ build_flags =
 ; commas. Keep the whole -D flag single-quoted so the value reaches the C
 ; preprocessor as a string. Omit this flag to use automatic seed discovery.
   '-DVIVINT_SEEDS="0016-0357157=e4d8,0016-0345744=1e35,0016-0357170=c283"'
-  '-DCC1101_RX_BANDWIDTH=270.83'
-  '-DCC1101_AGCCTRL2=0x83'
+  '-DCC1101_RX_BANDWIDTH=162.5'
+  '-DCC1101_AGCCTRL2=0x84'
   '-DCC1101_AGCCTRL1=0x40'
-  '-DCC1101_AGCCTRL0=0x90'
+  '-DCC1101_AGCCTRL0=0xA0'
 ;  '-DOUTPUT_VIVINT_DECODE=0' ; Disable seed status logging
 ; Seed and seed-discovery output fields are enabled by default. Uncomment to
 ; omit seed, decode_status, and seed-discovery counters from decoded messages.
@@ -296,7 +296,7 @@ build_flags =
   '-DCC1101_OOK_TUNING_EXTENDED'
 
 ; Direct alternating comparison of the promising AGCCTRL2=0x82 result against
-; the current 0x83 candidate. Both profiles use 345.10 MHz, 270.83 kHz,
+; the intermediate 0x83 candidate. Both profiles use 345.10 MHz, 270.83 kHz,
 ; AGCCTRL1=0x40, and AGCCTRL0=0x90. Five-minute windows alternate forever,
 ; with per-window results and cumulative totals for each profile.
 [env:esp32_cc1101_vivint_agc2_compare]
@@ -306,9 +306,9 @@ build_flags =
   '-DCC1101_OOK_PROFILE_COMPARE'
   '-DCC1101_OOK_AGC2_COMPARE'
 
-; Alternating complete-profile comparison. "current" is the existing
-; 345.10/270.83/0x83/0x40/0x90 recommendation; "extended_winner" is the
-; 345.12/325.0/0xC1/0x00/0x61 result assembled by the extended suite.
+; Alternating historical candidate comparison. "current" is the intermediate
+; 345.10/270.83/0x83/0x40/0x90 candidate; "extended_winner" is the
+; 345.12/325.0/0xC1/0x00/0x61 candidate assembled by the extended suite.
 ; Five-minute windows alternate forever and emit cumulative profile totals.
 [env:esp32_cc1101_vivint_extended_profile_compare]
 extends = env:esp32_cc1101_vivint_tuning
@@ -317,8 +317,8 @@ build_flags =
   '-DCC1101_OOK_PROFILE_COMPARE'
   '-DCC1101_OOK_EXTENDED_PROFILE_COMPARE'
 
-; Final comparison of the original documented Vivint recommendation
-; (345.00/162.5/0x84/0x40/0xA0) against the new recommendation
+; Final comparison of the released Vivint recommendation
+; (345.00/162.5/0x84/0x40/0xA0) against the extended candidate
 ; (345.12/325.0/0xC1/0x00/0x61). Five-minute windows alternate forever and
 ; emit both per-window results and cumulative profile totals.
 [env:esp32_cc1101_vivint_original_profile_compare]

--- a/examples/cc1101_tuning/README.md
+++ b/examples/cc1101_tuning/README.md
@@ -5,11 +5,33 @@ OOK/ASK tuning. It changes radio settings at five-minute intervals, scores the
 number of decoded messages, carries each phase winner forward, and prints
 machine-readable `TUNING_START`, `TUNING_RESULT`, and `TUNING_WINNER` records.
 
-The default configuration targets a Vivint test transmitter near 345 MHz that
-emits once every 30 seconds. Adjust the frequency, pins, seeds, test interval,
-and window duration in `platformio.ini` for another installation.
+## Vivint 345 MHz tuning
 
-## Running a suite
+The Vivint tuning, including the extended tuning and subsequent validation,
+was performed with Vivint devices at 345 MHz. The default configuration targets
+a Vivint test transmitter that emits once every 30 seconds. Adjust the
+frequency, pins, seeds, test interval, and window duration in `platformio.ini`
+for another installation.
+
+### Antenna length
+
+A free-space quarter wavelength at 345 MHz is approximately 8.55 inches
+(217 mm). The supplied spring was wound on approximately a 9/64-inch (3.57 mm)
+diameter and contained approximately 12 inches of conductor when unwound. Its
+original resonant frequency was not measured; it is believed to have been a
+nominal 433 MHz antenna supplied with the CC1101 receiver.
+
+The side-by-side test used two receivers named `north` and `south`; these are
+device names without positional or directional meaning. The `north` device had
+an approximately 8 1/2-inch straight whip and the `south` device had an
+approximately 8 3/4-inch straight whip. Their observed 345 MHz receive
+performance was about the same, but receiver differences remain confounded with
+antenna length. The antenna has a slotted barrel approximately 1/4 inch long,
+and its exact electrical contribution is unknown. See the formal discussion in
+[CC1101 Vivint tuning results](../../docs/CC1101_VIVINT_TUNING_RESULTS.md)
+before reproducing the antenna change or interpreting the comparison.
+
+### Running a Vivint suite
 
 Open this directory as the PlatformIO project, or run:
 
@@ -24,29 +46,43 @@ has zero decoded messages, the suite aborts and leaves reception active on the
 last setting for hardware diagnosis. After all phases complete, the selected
 combination runs in repeated validation windows.
 
-## Environments
+### Vivint environments
 
 | Environment | Purpose | Initial duration |
 | --- | --- | ---: |
-| `esp32_cc1101_vivint_tuning` | Broad first-pass search | 2 h 30 min |
-| `esp32_cc1101_vivint_refinement` | Fine frequency, bandwidth, and AGC search | 2 h 15 min |
+| `esp32_cc1101_vivint_tuning` | Focused post-antenna-trim search | 1 h 55 min |
+| `esp32_cc1101_vivint_refinement` | Fine frequency, bandwidth, and AGC search | 2 h 25 min |
 | `esp32_cc1101_vivint_extended_tuning` | Detailed AGC bit-field characterization | 2 h 35 min |
+| `esp32_cc1101_vivint_final_exploration` | Narrow search around the released profile | 1 h 40 min |
 | `esp32_cc1101_vivint_agc2_compare` | Alternating `AGCCTRL2=0x82` and `0x83` | Continuous |
 | `esp32_cc1101_vivint_extended_profile_compare` | Intermediate versus extended profile | Continuous |
 | `esp32_cc1101_vivint_original_profile_compare` | Original versus extended profile | Continuous |
-| `esp32_cc1101_43392_tuning` | Generic 433.92 MHz sweep with reference events | 28 min |
-| `esp32_cc1101_43392_focused_compare` | 12-profile 433.92 MHz focused comparison | Continuous |
-| `esp32_cc1101_43392_default_ab` | Library defaults versus focused result | Continuous |
-| `esp32_cc1101_43392_freq_bw_matrix` | 9-frequency by 4-bandwidth matrix | 36 min/cycle |
+| `esp32_cc1101_vivint_post_trim_compare` | Released Vivint profile versus post-trim candidate | Continuous |
+| `esp32_cc1101_vivint_post_trim_frequency_compare` | Isolated 345.00 versus 345.10 MHz comparison | Continuous |
+| `esp32_cc1101_vivint_post_trim_bandwidth_compare` | Isolated 162.5 versus 203.125 kHz comparison | Continuous |
+| `esp32_cc1101_vivint_post_trim_agcctrl2_compare` | Isolated `AGCCTRL2=0x84` versus `0xC7` comparison | Continuous |
+| `esp32_cc1101_vivint_post_trim_agcctrl0_compare` | Isolated `AGCCTRL0=0xA0` versus `0x90` comparison | Continuous |
+| `esp32_cc1101_vivint_final_exploration_compare` | Released profile versus narrow-exploration candidate | Continuous |
+| `esp32_cc1101_vivint_final_agcctrl2_compare` | Isolated `AGCCTRL2=0x84` versus `0x86` comparison | Continuous |
+| `esp32_cc1101_vivint_final_frequency_compare` | Isolated 345.00 versus 345.02 MHz comparison | Continuous |
+| `esp32_cc1101_vivint_counter_loss_compare` | Counter continuity for `AGCCTRL2=0x84/0x85/0x86` | Continuous |
+| `esp32_cc1101_vivint_counter_bandwidth_compare` | Counter continuity for adjacent bandwidths | Continuous |
+| `esp32_cc1101_vivint_counter_agc_wait_compare` | Counter continuity for AGC wait time | Continuous |
+| `esp32_cc1101_vivint_counter_agc_filter_compare` | Counter continuity for AGC filter length | Continuous |
+| `esp32_cc1101_vivint_counter_agc_hyst_compare` | Counter continuity for AGC hysteresis | Continuous |
 
-Comparison environments alternate five-minute windows and emit cumulative
-`PROFILE_TOTAL` records. A three-hour comparison gives 18 windows per profile.
+Comparison environments emit cumulative `PROFILE_TOTAL` records. Most use
+five-minute windows, so a two-profile three-hour comparison gives 18 windows
+per profile. The counter-continuity environments use ten-minute windows.
 
-## Final tested Vivint result
+### Final tested Vivint result
 
-The final 56-window-per-profile comparison favored the original profile by
-6,080 decoded messages to 5,221. It won 53 paired windows, lost two, and tied
-one. For the tested installation the recommendation remains:
+The earlier 56-window-per-profile comparison established the tuned profile.
+A later repeat-yield test appeared to favor `AGCCTRL2=0x86`, but a
+production-style counter-continuity test superseded that result: `0x84` and
+`0x85` had no counter gaps, while `0x86` lost 16 counters in two windows.
+Bandwidth and the remaining AGC fields were then isolated using the same
+counter-based scoring. For the tested installation the recommendation is:
 
 ```ini
 -DRF_MODULE_FREQUENCY=345.00
@@ -60,66 +96,3 @@ These values are installation-specific. Antenna characteristics, CC1101
 crystal tolerance, local interference, and transmitter offset can change the
 best result.
 
-## Comparing with an RTL-SDR reference
-
-The 433.92 MHz environment emits machine-readable `CC1101_EVENT` records. The
-host harness captures those alongside a local `rtl_433` process, correlates
-events by device identity and time, and writes JSON and CSV reports. It starts
-rtl_433 with an isolated configuration, so user MQTT settings are not inherited.
-
-```bash
-python3 tools/cc1101_reference_test.py \
-  --serial /dev/cu.usbserial-0001 --duration 10m
-```
-
-Repeated `--target key=value` options restrict scoring to a stable transmitter,
-for example `--target model=Acurite-Tower --target id=1234`.
-
-### Initial 433.92 MHz result
-
-An August 26, 2026 local sweep used 60-second windows and an RTL-SDR reference.
-The suite selected the following profile, which then matched 22 of 22 reference
-events over two final-validation windows:
-
-```ini
--DRF_MODULE_FREQUENCY=433.88
--DCC1101_RX_BANDWIDTH=232.143
--DCC1101_AGCCTRL2=0xC7
--DCC1101_AGCCTRL1=0x40
--DCC1101_AGCCTRL0=0x93
-```
-
-This is an installation-specific first pass. Most neighboring frequency,
-bandwidth, and AGC candidates also matched all reference events, so a longer
-alternating comparison is needed before changing the library defaults.
-
-A subsequent two-cycle focused comparison scored only the weakest regularly
-observed device (`Acurite-Tower`, id `2043`). The earlier
-433.88/232.143/0x93 profile matched 7 of 8 reference events. The selected
-focused profile matched 8 of 8:
-
-```ini
--DRF_MODULE_FREQUENCY=433.92
--DCC1101_RX_BANDWIDTH=203.125
--DCC1101_AGCCTRL2=0xC7
--DCC1101_AGCCTRL1=0x40
--DCC1101_AGCCTRL0=0x93
-```
-
-### Frequency/bandwidth matrix
-
-An August 27, 2026 matrix tested center frequencies from 433.820 through
-434.020 MHz and receive bandwidths of 203.125, 270.833, 325.0, and 406.25 kHz.
-The selected Acurite Tower transmitted every approximately 16.25 seconds. The
-203.125 kHz setting decoded no target events at 433.820--433.870 MHz, then
-decoded every expected event at 433.895 and 433.920 MHz. This indicates that
-the tested sensor's carrier is above nominal, approximately 433.98 MHz.
-
-The RTL-SDR reference became unreliable during this run: it decoded only 6
-target events while the CC1101 decoded 117, compared with 72 reference events
-in the preceding 20-minute A/B test. Restarting and offsetting the SDR did not
-restore its normal cadence. Consequently, this matrix is useful for locating
-the CC1101 passband boundary but is not a valid reference-scored sensitivity
-comparison. The fixed recommendation remains 433.920 MHz / 203.125 kHz because
-it decoded every expected event and the matrix did not demonstrate an improved
-capture rate at another passing center frequency.

--- a/examples/cc1101_tuning/cc1101_tuning.ino
+++ b/examples/cc1101_tuning/cc1101_tuning.ino
@@ -9,16 +9,18 @@
    -DCC1101_OOK_TUNING
    -DRF_MODULE_FREQUENCY=345.0
 
- The suite runs frequency, bandwidth, AGCCTRL2, and AGCCTRL0 phases in order,
- automatically carries each winner forward, then validates the final setting.
+ The suite runs frequency, bandwidth, AGCCTRL2, AGCCTRL1, and AGCCTRL0 phases
+ in order, automatically carries each winner forward, then validates the final
+ setting.
  Define CC1101_OOK_TUNING_REFINEMENT to use a focused search around the winning
  Vivint settings instead of the broad first-pass search.
  Define CC1101_OOK_TUNING_EXTENDED to characterize the remaining bandwidth,
  AGCCTRL2, AGCCTRL1, and AGCCTRL0 bit fields around the latest candidate.
- Optional starting values:
-   -DCC1101_TUNING_BASE_BANDWIDTH=406.0
-   -DCC1101_TUNING_BASE_AGCCTRL2=0x03
-   -DCC1101_TUNING_BASE_AGCCTRL0=0x91
+ Optional historical-suite starting values (not the released profile):
+   -DCC1101_TUNING_BASE_BANDWIDTH=270.833
+   -DCC1101_TUNING_BASE_AGCCTRL2=0x83
+   -DCC1101_TUNING_BASE_AGCCTRL1=0x40
+   -DCC1101_TUNING_BASE_AGCCTRL0=0x90
 
  Each setting runs for 300 seconds by default. Override with
  CC1101_TUNING_WINDOW_SECONDS and CC1101_TUNING_SIGNAL_INTERVAL_SECONDS.
@@ -57,6 +59,9 @@ volatile int count = 0;
 #  ifndef CC1101_TUNING_BASE_AGCCTRL2
 #    define CC1101_TUNING_BASE_AGCCTRL2 0x03
 #  endif
+#  ifndef CC1101_TUNING_BASE_AGCCTRL1
+#    define CC1101_TUNING_BASE_AGCCTRL1 0x40
+#  endif
 #  ifndef CC1101_TUNING_BASE_AGCCTRL0
 #    define CC1101_TUNING_BASE_AGCCTRL0 0x91
 #  endif
@@ -79,6 +84,7 @@ enum CC1101TuningPhase : uint8_t {
   TUNING_FREQUENCY = 1,
   TUNING_BANDWIDTH,
   TUNING_AGCCTRL2,
+  TUNING_AGCCTRL1,
   TUNING_AGCCTRL0,
   TUNING_AGCCTRL2_DVGA,
   TUNING_AGCCTRL2_LNA,
@@ -150,19 +156,81 @@ const CC1101TuningSetting profileValues[] = {
     {433.92f, 203.125f, 0xC7, 0x40, 0x93},
     {433.88f, 232.143f, 0xC7, 0x40, 0x93},
     {433.92f, 270.833f, 0xC7, 0x40, 0x90},
+#    elif defined(CC1101_OOK_POST_TRIM_PROFILE_COMPARE)
+    // Released Vivint recommendation versus the post-antenna-trim candidate.
+    {345.00f, 162.5f, 0x84, 0x40, 0xA0},
+    {345.10f, 203.125f, 0xC7, 0x40, 0x90},
+#    elif defined(CC1101_OOK_FINAL_EXPLORATION_COMPARE)
+    // Released profile versus the candidate from the final narrow exploration.
+    {345.00f, 162.5f, 0x84, 0x40, 0xA0},
+    {345.02f, 162.5f, 0x86, 0x40, 0x90},
+#    elif defined(CC1101_OOK_FINAL_AGCCTRL2_COMPARE)
+    // Isolate the exploration AGCCTRL2 result at the released frequency.
+    {345.00f, 162.5f, 0x84, 0x40, 0xA0},
+    {345.00f, 162.5f, 0x86, 0x40, 0xA0},
+#    elif defined(CC1101_OOK_FINAL_FREQUENCY_COMPARE)
+    // Isolate the 20 kHz frequency offset using the exploratory 0x86 value.
+    {345.00f, 162.5f, 0x86, 0x40, 0xA0},
+    {345.02f, 162.5f, 0x86, 0x40, 0xA0},
+#    elif defined(CC1101_OOK_COUNTER_LOSS_COMPARE)
+    // Production-style comparison: count unique Vivint counters rather than
+    // rewarding multiple decoded repeats from the same transmission.
+    {345.00f, 162.5f, 0x84, 0x40, 0xA0},
+    {345.00f, 162.5f, 0x85, 0x40, 0xA0},
+    {345.00f, 162.5f, 0x86, 0x40, 0xA0},
+#    elif defined(CC1101_OOK_COUNTER_BANDWIDTH_COMPARE)
+    // Adjacent valid CC1101 bandwidths using the gap-free AGCCTRL2 baseline.
+    {345.00f, 135.417f, 0x84, 0x40, 0xA0},
+    {345.00f, 162.5f, 0x84, 0x40, 0xA0},
+    {345.00f, 203.125f, 0x84, 0x40, 0xA0},
+    {345.00f, 232.143f, 0x84, 0x40, 0xA0},
+#    elif defined(CC1101_OOK_COUNTER_AGC_WAIT_COMPARE)
+    // AGCCTRL0[5:4] AGC_WAIT_TIME values with all other fields unchanged.
+    {345.00f, 162.5f, 0x84, 0x40, 0x80},
+    {345.00f, 162.5f, 0x84, 0x40, 0x90},
+    {345.00f, 162.5f, 0x84, 0x40, 0xA0},
+    {345.00f, 162.5f, 0x84, 0x40, 0xB0},
+#    elif defined(CC1101_OOK_COUNTER_AGC_FILTER_COMPARE)
+    // AGCCTRL0[1:0] FILTER_LENGTH values with the confirmed 0xA0 baseline.
+    {345.00f, 162.5f, 0x84, 0x40, 0xA0},
+    {345.00f, 162.5f, 0x84, 0x40, 0xA1},
+    {345.00f, 162.5f, 0x84, 0x40, 0xA2},
+    {345.00f, 162.5f, 0x84, 0x40, 0xA3},
+#    elif defined(CC1101_OOK_COUNTER_AGC_HYST_COMPARE)
+    // AGCCTRL0[7:6] HYST_LEVEL values; wait, freeze, and filter stay fixed.
+    {345.00f, 162.5f, 0x84, 0x40, 0x20},
+    {345.00f, 162.5f, 0x84, 0x40, 0x60},
+    {345.00f, 162.5f, 0x84, 0x40, 0xA0},
+    {345.00f, 162.5f, 0x84, 0x40, 0xE0},
+#    elif defined(CC1101_OOK_POST_TRIM_FREQUENCY_COMPARE)
+    // Isolate only the frequency change; retain the released Vivint settings.
+    {345.00f, 162.5f, 0x84, 0x40, 0xA0},
+    {345.10f, 162.5f, 0x84, 0x40, 0xA0},
+#    elif defined(CC1101_OOK_POST_TRIM_BANDWIDTH_COMPARE)
+    // Isolate only the bandwidth change; retain the released Vivint settings.
+    {345.00f, 162.5f, 0x84, 0x40, 0xA0},
+    {345.00f, 203.125f, 0x84, 0x40, 0xA0},
+#    elif defined(CC1101_OOK_POST_TRIM_AGCCTRL2_COMPARE)
+    // Isolate only AGCCTRL2; retain the other released Vivint settings.
+    {345.00f, 162.5f, 0x84, 0x40, 0xA0},
+    {345.00f, 162.5f, 0xC7, 0x40, 0xA0},
+#    elif defined(CC1101_OOK_POST_TRIM_AGCCTRL0_COMPARE)
+    // Isolate only AGCCTRL0; retain the other released Vivint settings.
+    {345.00f, 162.5f, 0x84, 0x40, 0xA0},
+    {345.00f, 162.5f, 0x84, 0x40, 0x90},
 #    elif defined(CC1101_OOK_ORIGINAL_PROFILE_COMPARE)
-    // Original documented Vivint recommendation versus the extended-suite
-    // winner selected by the long alternating comparison.
+    // Released Vivint recommendation versus the extended-suite candidate
+    // rejected by the final long alternating comparison.
     {345.00f, 162.5f, 0x84, 0x40, 0xA0},
     {345.12f, 325.0f, 0xC1, 0x00, 0x61},
 #    elif defined(CC1101_OOK_EXTENDED_PROFILE_COMPARE)
-    // Current recommendation versus the complete winner assembled by the
-    // extended characterization suite.
+    // Intermediate candidate versus the candidate assembled by the extended
+    // characterization suite.
     {345.10f, 270.833f, 0x83, 0x40, 0x90},
     {345.12f, 325.0f, 0xC1, 0x00, 0x61},
 #    elif defined(CC1101_OOK_AGC2_COMPARE)
     // Direct Vivint comparison of the clean 30 dB magnitude-target result
-    // against the current 33 dB candidate. All other settings remain fixed.
+    // against the intermediate 33 dB candidate. All other settings remain fixed.
     {345.10f, 270.833f, 0x82, 0x40, 0x90},
     {345.10f, 270.833f, 0x83, 0x40, 0x90},
 #    else
@@ -191,8 +259,38 @@ const char* const profileNames[] = {
     "f92_bw203_a090", "f88_bw232_a090", "f92_bw270_a093",
     "f88_bw203_a093", "f92_bw232_a090", "f88_bw270_a090",
     "f92_bw203_a093", "f88_bw232_a093", "f92_bw270_a090"};
+#    elif defined(CC1101_OOK_POST_TRIM_PROFILE_COMPARE)
+const char* const profileNames[] = {"released_vivint", "post_trim_candidate"};
+#    elif defined(CC1101_OOK_FINAL_EXPLORATION_COMPARE)
+const char* const profileNames[] = {"released_vivint", "final_exploration_candidate"};
+#    elif defined(CC1101_OOK_FINAL_AGCCTRL2_COMPARE)
+const char* const profileNames[] = {"agcctrl2_0x84", "agcctrl2_0x86"};
+#    elif defined(CC1101_OOK_FINAL_FREQUENCY_COMPARE)
+const char* const profileNames[] = {"frequency_345_00", "frequency_345_02"};
+#    elif defined(CC1101_OOK_COUNTER_LOSS_COMPARE)
+const char* const profileNames[] = {"agcctrl2_0x84", "agcctrl2_0x85", "agcctrl2_0x86"};
+#    elif defined(CC1101_OOK_COUNTER_BANDWIDTH_COMPARE)
+const char* const profileNames[] = {"bandwidth_135_417", "bandwidth_162_5",
+                                    "bandwidth_203_125", "bandwidth_232_143"};
+#    elif defined(CC1101_OOK_COUNTER_AGC_WAIT_COMPARE)
+const char* const profileNames[] = {"agc_wait_0x80", "agc_wait_0x90",
+                                    "agc_wait_0xA0", "agc_wait_0xB0"};
+#    elif defined(CC1101_OOK_COUNTER_AGC_FILTER_COMPARE)
+const char* const profileNames[] = {"agc_filter_0xA0", "agc_filter_0xA1",
+                                    "agc_filter_0xA2", "agc_filter_0xA3"};
+#    elif defined(CC1101_OOK_COUNTER_AGC_HYST_COMPARE)
+const char* const profileNames[] = {"agc_hyst_0x20", "agc_hyst_0x60",
+                                    "agc_hyst_0xA0", "agc_hyst_0xE0"};
+#    elif defined(CC1101_OOK_POST_TRIM_FREQUENCY_COMPARE)
+const char* const profileNames[] = {"frequency_345_00", "frequency_345_10"};
+#    elif defined(CC1101_OOK_POST_TRIM_BANDWIDTH_COMPARE)
+const char* const profileNames[] = {"bandwidth_162_5", "bandwidth_203_125"};
+#    elif defined(CC1101_OOK_POST_TRIM_AGCCTRL2_COMPARE)
+const char* const profileNames[] = {"agcctrl2_0x84", "agcctrl2_0xC7"};
+#    elif defined(CC1101_OOK_POST_TRIM_AGCCTRL0_COMPARE)
+const char* const profileNames[] = {"agcctrl0_0xA0", "agcctrl0_0x90"};
 #    elif defined(CC1101_OOK_ORIGINAL_PROFILE_COMPARE)
-const char* const profileNames[] = {"original", "new_recommendation"};
+const char* const profileNames[] = {"released_profile", "extended_candidate"};
 #    elif defined(CC1101_OOK_EXTENDED_PROFILE_COMPARE)
 const char* const profileNames[] = {"current", "extended_winner"};
 #    elif defined(CC1101_OOK_AGC2_COMPARE)
@@ -204,6 +302,9 @@ unsigned long profileWindows[sizeof(profileValues) / sizeof(profileValues[0])] =
 unsigned long profileSignals[sizeof(profileValues) / sizeof(profileValues[0])] = {};
 unsigned long profileDecoded[sizeof(profileValues) / sizeof(profileValues[0])] = {};
 unsigned long profileZero[sizeof(profileValues) / sizeof(profileValues[0])] = {};
+unsigned long profileUniqueCounters[sizeof(profileValues) / sizeof(profileValues[0])] = {};
+unsigned long profileDuplicateCounters[sizeof(profileValues) / sizeof(profileValues[0])] = {};
+unsigned long profileCounterGaps[sizeof(profileValues) / sizeof(profileValues[0])] = {};
 #  elif defined(CC1101_OOK_TUNING_EXTENDED)
 // Focused characterization around the long-run candidate. Values for the
 // split AGC phases are field values and are merged with the winning register
@@ -226,6 +327,7 @@ const float frequencyValues[] = {433.92f, 433.88f, 433.96f, 433.84f,
 const float bandwidthValues[] = {812.0f, 650.0f, 406.0f, 325.0f, 270.833f,
                                  232.143f, 203.125f, 162.5f};
 const uint8_t agcctrl2Values[] = {0x03, 0x07, 0x43, 0x83, 0xC7};
+const uint8_t agcctrl1Values[] = {0x00, 0x40};
 const uint8_t agcctrl0Values[] = {0x90, 0x91, 0x92, 0x93};
 #  elif defined(CC1101_OOK_TUNING_REFINEMENT)
 // Fine frequency grid around 345.10 MHz. CC1101 receive bandwidths are
@@ -237,16 +339,34 @@ const float bandwidthValues[] = {162.5f, 203.125f, 232.143f, 270.833f};
 // Hold MAX_DVGA_GAIN at the winning value and refine MAGN_TARGET.
 const uint8_t agcctrl2Values[] = {0x80, 0x81, 0x82, 0x83,
                                   0x84, 0x85, 0x86, 0x87};
+const uint8_t agcctrl1Values[] = {0x00, 0x40};
 // Hold hysteresis, freeze, and filter length at the winner while testing each
 // AGC_WAIT_TIME value.
 const uint8_t agcctrl0Values[] = {0x80, 0x90, 0xA0, 0xB0};
+#  elif defined(CC1101_OOK_FINAL_EXPLORATION)
+// Final one-knob-at-a-time exploration around the released Vivint profile.
+// Frequencies stay close enough to 345.00 MHz to preserve reception while
+// checking crystal/antenna offset in 10 kHz increments.
+const float frequencyValues[] = {344.97f, 344.98f, 344.99f, 345.00f,
+                                 345.01f, 345.02f, 345.03f};
+// These are adjacent valid CC1101 channel-filter settings.
+const float bandwidthValues[] = {135.417f, 162.5f, 203.125f};
+// Preserve MAX_DVGA_GAIN=2 while checking neighboring MAGN_TARGET values.
+const uint8_t agcctrl2Values[] = {0x82, 0x83, 0x84, 0x85, 0x86};
+const uint8_t agcctrl1Values[] = {0x00, 0x40};
+// Compare AGC wait times with the released hysteresis/filter fields intact.
+const uint8_t agcctrl0Values[] = {0x90, 0xA0, 0xB0};
 #  else
-const float frequencyValues[] = {344.50f, 344.60f, 344.70f, 344.80f,
-                                 344.90f, 345.00f, 345.10f, 345.20f,
-                                 345.30f, 345.40f, 345.50f};
-const float bandwidthValues[] = {812.0f, 650.0f, 406.0f, 325.0f, 270.0f,
-                                 203.0f, 162.0f, 116.0f, 81.0f, 58.0f};
+// The initial antenna-tuning run found no decodes at 344.80 MHz and below or
+// at 345.20 MHz and above. Keep the boundary points while resolving the useful
+// region in 50 kHz steps.
+const float frequencyValues[] = {344.90f, 344.95f, 345.00f, 345.05f,
+                                 345.10f, 345.15f, 345.20f};
+// The post-trim run found its useful bandwidth region between 162.5 and
+// 325 kHz, with 203.125 kHz winning. Retain the neighboring hardware points.
+const float bandwidthValues[] = {162.5f, 203.125f, 232.143f, 270.833f, 325.0f};
 const uint8_t agcctrl2Values[] = {0x03, 0x07, 0x43, 0x83, 0xC7};
+const uint8_t agcctrl1Values[] = {0x00, 0x40};
 const uint8_t agcctrl0Values[] = {0x90, 0x91, 0x92, 0x93};
 #  endif
 
@@ -265,7 +385,8 @@ CC1101TuningSetting selectedSetting = {345.10f, 203.125f, 0x83, 0x40, 0x90};
 #  else
 CC1101TuningSetting selectedSetting = {
     RF_MODULE_FREQUENCY, CC1101_TUNING_BASE_BANDWIDTH,
-    CC1101_TUNING_BASE_AGCCTRL2, 0x40, CC1101_TUNING_BASE_AGCCTRL0};
+    CC1101_TUNING_BASE_AGCCTRL2, CC1101_TUNING_BASE_AGCCTRL1,
+    CC1101_TUNING_BASE_AGCCTRL0};
 #  endif
 size_t tuningSettingIndex = 0;
 unsigned long tuningWindowStartedMs = 0;
@@ -276,11 +397,54 @@ unsigned int bestZeroDecoded = 0xFFFF;
 int bestRssi = -1000;
 CC1101TuningSetting bestSetting;
 CC1101TuningSetting tuningSetting(size_t index);
+
+struct CounterTracker {
+  char id[24];
+  uint32_t lastCounter;
+  bool active;
+};
+CounterTracker counterTrackers[4] = {};
+unsigned int uniqueCounterCount = 0;
+unsigned int duplicateCounterCount = 0;
+unsigned int counterGapCount = 0;
+
+void recordVivintCounter(JsonDocument& message) {
+  if (!message["counter"].is<uint32_t>() || !message["id"].is<const char*>()) return;
+  const char* id = message["id"];
+  uint32_t counter = message["counter"].as<uint32_t>();
+  CounterTracker* tracker = nullptr;
+  for (CounterTracker& item : counterTrackers) {
+    if (item.active && strcmp(item.id, id) == 0) {
+      tracker = &item;
+      break;
+    }
+    if (!item.active && tracker == nullptr) tracker = &item;
+  }
+  if (tracker == nullptr) return;
+  if (!tracker->active) {
+    strlcpy(tracker->id, id, sizeof(tracker->id));
+    tracker->lastCounter = counter;
+    tracker->active = true;
+    uniqueCounterCount++;
+    return;
+  }
+  if (counter == tracker->lastCounter) {
+    duplicateCounterCount++;
+    return;
+  }
+  uint32_t delta = counter - tracker->lastCounter;
+  if (delta > 1 && delta < 1000) counterGapCount += delta - 1;
+  tracker->lastCounter = counter;
+  uniqueCounterCount++;
+}
 #endif
 
 void rtl_433_Callback(char* message) {
   JsonDocument jsonDocument;
   deserializeJson(jsonDocument, message);
+#if defined(CC1101_OOK_TUNING)
+  recordVivintCounter(jsonDocument);
+#endif
   logJson(jsonDocument);
   count++;
 }
@@ -344,6 +508,7 @@ const char* tuningPhaseName() {
     case TUNING_FREQUENCY: return "frequency";
     case TUNING_BANDWIDTH: return "bandwidth";
     case TUNING_AGCCTRL2: return "agcctrl2";
+    case TUNING_AGCCTRL1: return "agcctrl1";
     case TUNING_AGCCTRL0: return "agcctrl0";
     case TUNING_AGCCTRL2_DVGA: return "agcctrl2_dvga";
     case TUNING_AGCCTRL2_LNA: return "agcctrl2_lna";
@@ -364,6 +529,9 @@ size_t tuningSettingCount() {
     case TUNING_FREQUENCY: return sizeof(frequencyValues) / sizeof(frequencyValues[0]);
     case TUNING_BANDWIDTH: return sizeof(bandwidthValues) / sizeof(bandwidthValues[0]);
     case TUNING_AGCCTRL2: return sizeof(agcctrl2Values) / sizeof(agcctrl2Values[0]);
+#  if !defined(CC1101_OOK_TUNING_EXTENDED)
+    case TUNING_AGCCTRL1: return sizeof(agcctrl1Values) / sizeof(agcctrl1Values[0]);
+#  endif
     case TUNING_AGCCTRL0: return sizeof(agcctrl0Values) / sizeof(agcctrl0Values[0]);
 #  if defined(CC1101_OOK_TUNING_EXTENDED)
     case TUNING_AGCCTRL2_DVGA: return sizeof(agcctrl2DvgaValues) / sizeof(agcctrl2DvgaValues[0]);
@@ -394,6 +562,9 @@ CC1101TuningSetting tuningSetting(size_t index) {
 #  endif
       break;
     case TUNING_AGCCTRL0: setting.agcctrl0 = agcctrl0Values[index]; break;
+#  if !defined(CC1101_OOK_TUNING_EXTENDED)
+    case TUNING_AGCCTRL1: setting.agcctrl1 = agcctrl1Values[index]; break;
+#  endif
 #  if defined(CC1101_OOK_TUNING_EXTENDED)
     case TUNING_AGCCTRL2_DVGA:
       setting.agcctrl2 = (setting.agcctrl2 & 0x3F) | agcctrl2DvgaValues[index]; break;
@@ -433,6 +604,10 @@ void resetTuningStatistics() {
   rtl_433_ESP::decoderSignals = 0;
   rtl_433_ESP::decodedMessages = 0;
   rtl_433_ESP::zeroDecodedSignals = 0;
+  memset(counterTrackers, 0, sizeof(counterTrackers));
+  uniqueCounterCount = 0;
+  duplicateCounterCount = 0;
+  counterGapCount = 0;
 }
 
 void applyTuningSetting(size_t index) {
@@ -483,6 +658,9 @@ unsigned int finishTuningSetting() {
   unsigned int capturedDecoderSignals = rtl_433_ESP::decoderSignals;
   unsigned int capturedDecodedMessages = rtl_433_ESP::decodedMessages;
   unsigned int capturedZeroDecoded = rtl_433_ESP::zeroDecodedSignals;
+  unsigned int capturedUniqueCounters = uniqueCounterCount;
+  unsigned int capturedDuplicateCounters = duplicateCounterCount;
+  unsigned int capturedCounterGaps = counterGapCount;
 
   long meanRssi = capturedRawCount ? capturedRssiTotal / (long)capturedRawCount : 0;
   unsigned long meanPulses =
@@ -491,6 +669,7 @@ unsigned int finishTuningSetting() {
       F("TUNING_RESULT phase=%s profile=%s setting=%u/%u frequency_mhz=%F bandwidth_khz=%F "
         "agcctrl2=0x%x agcctrl1=0x%x agcctrl0=0x%x elapsed_s=%u expected=%u raw=%u "
         "decoder_signals=%u decoded_messages=%u decoded_zero=%u callback_messages=%d "
+        "unique_counters=%u duplicate_repeats=%u counter_gaps=%u "
         "rssi_mean=%d rssi_min=%d rssi_max=%d pulses_mean=%u" CR),
       tuningPhaseName(), tuningSettingName(tuningSettingIndex),
       (unsigned int)(tuningSettingIndex + 1),
@@ -501,7 +680,8 @@ unsigned int finishTuningSetting() {
       (unsigned int)(CC1101_TUNING_WINDOW_SECONDS /
                      CC1101_TUNING_SIGNAL_INTERVAL_SECONDS),
       capturedRawCount, capturedDecoderSignals, capturedDecodedMessages,
-      capturedZeroDecoded, capturedDecodedCount, (int)meanRssi,
+      capturedZeroDecoded, capturedDecodedCount, capturedUniqueCounters,
+      capturedDuplicateCounters, capturedCounterGaps, (int)meanRssi,
       capturedRawCount ? capturedRssiMin : 0,
       capturedRawCount ? capturedRssiMax : 0, (unsigned int)meanPulses);
 
@@ -510,14 +690,21 @@ unsigned int finishTuningSetting() {
   profileSignals[tuningSettingIndex] += capturedDecoderSignals;
   profileDecoded[tuningSettingIndex] += capturedDecodedMessages;
   profileZero[tuningSettingIndex] += capturedZeroDecoded;
+  profileUniqueCounters[tuningSettingIndex] += capturedUniqueCounters;
+  profileDuplicateCounters[tuningSettingIndex] += capturedDuplicateCounters;
+  profileCounterGaps[tuningSettingIndex] += capturedCounterGaps;
   Log.notice(
       F("PROFILE_TOTAL profile=%s windows=%u decoder_signals=%u "
-        "decoded_messages=%u decoded_zero=%u" CR),
+        "decoded_messages=%u decoded_zero=%u unique_counters=%u "
+        "duplicate_repeats=%u counter_gaps=%u" CR),
       tuningSettingName(tuningSettingIndex),
       (unsigned int)profileWindows[tuningSettingIndex],
       (unsigned int)profileSignals[tuningSettingIndex],
       (unsigned int)profileDecoded[tuningSettingIndex],
-      (unsigned int)profileZero[tuningSettingIndex]);
+      (unsigned int)profileZero[tuningSettingIndex],
+      (unsigned int)profileUniqueCounters[tuningSettingIndex],
+      (unsigned int)profileDuplicateCounters[tuningSettingIndex],
+      (unsigned int)profileCounterGaps[tuningSettingIndex]);
 #  endif
 
   bool better = (int)capturedDecodedMessages > bestDecoded;
@@ -595,6 +782,8 @@ void completeTuningPhase() {
   } else if (tuningPhase == TUNING_BANDWIDTH) {
     tuningPhase = TUNING_AGCCTRL2;
   } else if (tuningPhase == TUNING_AGCCTRL2) {
+    tuningPhase = TUNING_AGCCTRL1;
+  } else if (tuningPhase == TUNING_AGCCTRL1) {
     tuningPhase = TUNING_AGCCTRL0;
   } else if (tuningPhase == TUNING_AGCCTRL0) {
     tuningPhase = TUNING_FINAL_VALIDATION;

--- a/examples/cc1101_tuning/platformio.ini
+++ b/examples/cc1101_tuning/platformio.ini
@@ -37,21 +37,115 @@ build_flags =
 [vivint]
 build_flags =
   '-DRF_MODULE_FREQUENCY=345.00'
-  '-DCC1101_TUNING_WINDOW_SECONDS=300'
   '-DVIVINT_SEEDS="0016-0357157=e4d8,0016-0345744=1e35,0016-0357170=c283"'
   '-DMINIMUM_SIGNAL_LENGTH=30000'
 
-; Broad first-pass search: 30 settings, approximately 2 hours 30 minutes,
+; Focused post-antenna-trim search: 23 settings, approximately 1 hour 55
+; minutes. Each phase carries its decoded-message winner into the next phase,
 ; followed by repeated validation windows on the selected combination.
 [env:esp32_cc1101_vivint_tuning]
 build_flags =
   ${env.build_flags}
   ${vivint.build_flags}
-  '-DCC1101_TUNING_BASE_BANDWIDTH=406.0'
-  '-DCC1101_TUNING_BASE_AGCCTRL2=0x03'
-  '-DCC1101_TUNING_BASE_AGCCTRL0=0x91'
+  '-DCC1101_TUNING_BASE_BANDWIDTH=203.125'
+  '-DCC1101_TUNING_BASE_AGCCTRL2=0xC7'
+  '-DCC1101_TUNING_BASE_AGCCTRL1=0x40'
+  '-DCC1101_TUNING_BASE_AGCCTRL0=0x90'
 
-; Fine second pass: 27 settings, approximately 2 hours 15 minutes.
+; Final post-antenna exploration around the released profile: 20 settings,
+; approximately 1 hour 40 minutes, followed by repeated winner validation.
+[env:esp32_cc1101_vivint_final_exploration]
+upload_speed = 460800
+build_flags =
+  ${env.build_flags}
+  ${vivint.build_flags}
+  '-DCC1101_OOK_FINAL_EXPLORATION'
+  '-DCC1101_TUNING_BASE_BANDWIDTH=162.5'
+  '-DCC1101_TUNING_BASE_AGCCTRL2=0x84'
+  '-DCC1101_TUNING_BASE_AGCCTRL1=0x40'
+  '-DCC1101_TUNING_BASE_AGCCTRL0=0xA0'
+
+; Released profile versus the winner from the final narrow exploration.
+; Alternates continuously in ten-minute A/B cycles.
+[env:esp32_cc1101_vivint_final_exploration_compare]
+upload_speed = 460800
+build_flags =
+  ${env.build_flags}
+  ${vivint.build_flags}
+  '-DCC1101_OOK_PROFILE_COMPARE'
+  '-DCC1101_OOK_FINAL_EXPLORATION_COMPARE'
+
+; Isolate AGCCTRL2 0x84 versus 0x86 at the released frequency/profile.
+[env:esp32_cc1101_vivint_final_agcctrl2_compare]
+upload_speed = 460800
+build_flags =
+  ${env.build_flags}
+  ${vivint.build_flags}
+  '-DCC1101_OOK_PROFILE_COMPARE'
+  '-DCC1101_OOK_FINAL_AGCCTRL2_COMPARE'
+
+; Isolate 345.00 versus 345.02 MHz using the confirmed AGCCTRL2 0x86.
+[env:esp32_cc1101_vivint_final_frequency_compare]
+upload_speed = 460800
+build_flags =
+  ${env.build_flags}
+  ${vivint.build_flags}
+  '-DCC1101_OOK_PROFILE_COMPARE'
+  '-DCC1101_OOK_FINAL_FREQUENCY_COMPARE'
+
+; Production-style counter-continuity test. Three AGCCTRL2 settings alternate
+; in ten-minute windows; duplicate repeats do not inflate the primary metric.
+[env:esp32_cc1101_vivint_counter_loss_compare]
+upload_speed = 460800
+build_flags =
+  ${env.build_flags}
+  ${vivint.build_flags}
+  '-DCC1101_TUNING_WINDOW_SECONDS=600'
+  '-DCC1101_OOK_PROFILE_COMPARE'
+  '-DCC1101_OOK_COUNTER_LOSS_COMPARE'
+
+; Counter-continuity comparison of adjacent valid CC1101 bandwidths using the
+; gap-free AGCCTRL2 0x84 baseline and ten-minute windows.
+[env:esp32_cc1101_vivint_counter_bandwidth_compare]
+upload_speed = 460800
+build_flags =
+  ${env.build_flags}
+  ${vivint.build_flags}
+  '-DCC1101_TUNING_WINDOW_SECONDS=600'
+  '-DCC1101_OOK_PROFILE_COMPARE'
+  '-DCC1101_OOK_COUNTER_BANDWIDTH_COMPARE'
+
+; Counter-continuity comparison of all AGCCTRL0 AGC_WAIT_TIME field values.
+[env:esp32_cc1101_vivint_counter_agc_wait_compare]
+upload_speed = 460800
+build_flags =
+  ${env.build_flags}
+  ${vivint.build_flags}
+  '-DCC1101_TUNING_WINDOW_SECONDS=600'
+  '-DCC1101_OOK_PROFILE_COMPARE'
+  '-DCC1101_OOK_COUNTER_AGC_WAIT_COMPARE'
+
+; Counter-continuity comparison of all AGCCTRL0 FILTER_LENGTH field values.
+[env:esp32_cc1101_vivint_counter_agc_filter_compare]
+upload_speed = 460800
+build_flags =
+  ${env.build_flags}
+  ${vivint.build_flags}
+  '-DCC1101_TUNING_WINDOW_SECONDS=600'
+  '-DCC1101_OOK_PROFILE_COMPARE'
+  '-DCC1101_OOK_COUNTER_AGC_FILTER_COMPARE'
+
+; Counter-continuity comparison of all AGCCTRL0 HYST_LEVEL field values.
+[env:esp32_cc1101_vivint_counter_agc_hyst_compare]
+upload_speed = 460800
+build_flags =
+  ${env.build_flags}
+  ${vivint.build_flags}
+  '-DCC1101_TUNING_WINDOW_SECONDS=600'
+  '-DCC1101_OOK_PROFILE_COMPARE'
+  '-DCC1101_OOK_COUNTER_AGC_HYST_COMPARE'
+
+; Fine second pass: 29 settings, approximately 2 hours 25 minutes.
 [env:esp32_cc1101_vivint_refinement]
 build_flags =
   ${env.build_flags}
@@ -89,6 +183,51 @@ build_flags =
   ${vivint.build_flags}
   '-DCC1101_OOK_PROFILE_COMPARE'
   '-DCC1101_OOK_ORIGINAL_PROFILE_COMPARE'
+
+; Released Vivint recommendation versus the profile selected after trimming
+; the antenna. Ten minutes per A/B cycle; alternates continuously.
+[env:esp32_cc1101_vivint_post_trim_compare]
+build_flags =
+  ${env.build_flags}
+  ${vivint.build_flags}
+  '-DCC1101_OOK_PROFILE_COMPARE'
+  '-DCC1101_OOK_POST_TRIM_PROFILE_COMPARE'
+
+; Isolate the post-trim frequency result while holding the released Vivint
+; bandwidth and AGC registers constant. Ten minutes per alternating A/B cycle.
+[env:esp32_cc1101_vivint_post_trim_frequency_compare]
+build_flags =
+  ${env.build_flags}
+  ${vivint.build_flags}
+  '-DCC1101_OOK_PROFILE_COMPARE'
+  '-DCC1101_OOK_POST_TRIM_FREQUENCY_COMPARE'
+
+; Isolate the post-trim bandwidth result at 345.00 MHz while holding the
+; released Vivint AGC registers constant.
+[env:esp32_cc1101_vivint_post_trim_bandwidth_compare]
+build_flags =
+  ${env.build_flags}
+  ${vivint.build_flags}
+  '-DCC1101_OOK_PROFILE_COMPARE'
+  '-DCC1101_OOK_POST_TRIM_BANDWIDTH_COMPARE'
+
+; Isolate the post-trim AGCCTRL2 result while holding the released Vivint
+; frequency, bandwidth, AGCCTRL1, and AGCCTRL0 constant.
+[env:esp32_cc1101_vivint_post_trim_agcctrl2_compare]
+build_flags =
+  ${env.build_flags}
+  ${vivint.build_flags}
+  '-DCC1101_OOK_PROFILE_COMPARE'
+  '-DCC1101_OOK_POST_TRIM_AGCCTRL2_COMPARE'
+
+; Isolate the post-trim AGCCTRL0 result while holding the released Vivint
+; frequency, bandwidth, AGCCTRL2, and AGCCTRL1 constant.
+[env:esp32_cc1101_vivint_post_trim_agcctrl0_compare]
+build_flags =
+  ${env.build_flags}
+  ${vivint.build_flags}
+  '-DCC1101_OOK_PROFILE_COMPARE'
+  '-DCC1101_OOK_POST_TRIM_AGCCTRL0_COMPARE'
 
 ; Generic 433.92 MHz sweep with per-event JSON for comparison against an SDR.
 [env:esp32_cc1101_43392_tuning]

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
         "type": "git",
         "url": "https://github.com/NorthernMan54/rtl_433_ESP.git"
     },
-    "version": "0.6.1",
+    "version": "0.6.2",
     "license": "GPL-3.0",
     "frameworks": "arduino",
     "platforms": [

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=rtl_433_ESP
-version=0.6.1
+version=0.6.2
 author=NorthernMan54 <19808920+NorthernMan54@users.noreply.github.com>
 maintainer=NorthernMan54 <19808920+NorthernMan54@users.noreply.github.com>
 sentence=RTL_433 protocol decoders for ESP32 radios.

--- a/src/rtl_433/devices/vivint.c
+++ b/src/rtl_433/devices/vivint.c
@@ -9,6 +9,7 @@
     (at your option) any later version.
 */
 
+#include "data.h"
 #include "decoder.h"
 
 #include <stdint.h>
@@ -30,11 +31,21 @@
 #if VIVINT_SEED_DATA_REQUIRED < 1 || VIVINT_SEED_DATA_REQUIRED > VIVINT_CACHED_COUNTERS
 #error "VIVINT_SEED_DATA_REQUIRED must be between 1 and VIVINT_CACHED_COUNTERS"
 #endif
-#define VIVINT_ENTRY_COUNTER 0x17
-#define VIVINT_RABBIT_CIPHER_SIZE 48
-#define VIVINT_EVENT_DW 0x7a
-#define VIVINT_EVENT_PIR 0x74
-#define VIVINT_EVENT_GB 0x79
+// TODO  #define VIVINT_CHANNEL 0x70
+#define VIVINT_ENTRY_COUNTER           0x17
+#define VIVINT_RABBIT_CIPHER_SIZE      48
+#define VIVINT_PACKET_STARTUP          0xd0
+#define VIVINT_PACKET_BATTERY          0x72
+#define VIVINT_PACKET_SEED             0x73
+#define VIVINT_PACKET_MFG_BOOT         0x76
+#define VIVINT_PACKET_EVENT_DW         0x7a
+#define VIVINT_PACKET_EVENT_PIR        0x74
+#define VIVINT_PACKET_EVENT_GB         0x79
+
+#define VIVINT_DEVICE_TYPE_V_PIR2_345  0x0a
+#define VIVINT_DEVICE_TYPE_V_DW21R_345 0x0f
+#define VIVINT_DEVICE_TYPE_V_GB2_345   0x14
+#define VIVINT_DEVICE_TYPE_V_DW11_345  0x18
 
 // Include seed and seed-discovery diagnostics in decoder output by default.
 // Define OUTPUT_VIVINT_DECODE=0 to omit these fields from emitted data.
@@ -51,13 +62,37 @@ The decoder also identifies PIR2 motion and GB2 glass-break frame types.
 OOK Manchester (zerobit), 0xFFFE preamble, 96 bit (12 byte) packet. Decoded
 payload (80 data bits, 10 bytes) after the preamble:
 
+    For the 0xd0 messages:
+
+    TT BB NN BB II II II II RR RR
+
+    For the 0x74, 0x79, and 0x7a messages:
+
     TT CC CC FF II II II II RR RR
 
-- T: 8 bit frame subtype: 0x7a = DW11 door/window, 0x79 = GB2 glass-break,
-     0x74 = PIR2 motion, 0x72/0x73/0x76 = other sensor families,
+    For the 0x72, 0x73, and 0x76 messages,
+
+
+- T: 8 bit frame subtype:
+     0x74 = PIR motion
+     0x79 = GB glass-break
+     0x7a = DW door/window
      0xd0 = power-on/startup beacon
+     0x72 = Heartbeat message
+     0x73 = Raw seed value
+     0x76 = Used during manufacturing bringup
+
+- N: 8 bit constant used to identify the type of device
+     0x0a: V-PIR2-345
+     0x0f: V-DW21R-345
+     0x14: V-GB2-345
+     0x18: V-DW11-345
+     Other unknown device values are the V-PIR3-345, V-GB3-345, keyfobs, flood, and some other sensors
+
+- B: 16 bit value that gives a device specific battery level
+
 - C: 16 bit counter, increments every transmission
-- F: 8 bit status byte. The low 2 bits are always zero; the rest (including
+- F: 8 bit status byte. The low 2 bits are always zero for a standard encrypted message; the rest (including
      bit 7, open/closed for 0x7a) are XORed with a per-device keystream,
      see below
 - I: 32 bit device identifier
@@ -132,8 +167,6 @@ See https://github.com/merbanan/rtl_433/issues/1504
    modeled as a flat byte window. Custom to this protocol (not part of
    RFC 4503): a 16-bit seed in place of Rabbit's 128-bit key/IV, and a
    per-packet schedule keyed off the transmission counter. */
-/* Technically, we could just cache the key and the secrets. The states
-   are generated every 12 packets */
 typedef struct {
     uint32_t C[8];
     uint32_t X[8];
@@ -154,10 +187,11 @@ static uint32_t vivint_rotl32(uint32_t x, unsigned n)
     return (x << n) | (x >> (32 - n));
 }
 
+/* Base of the rabbit cipher function 'g' */
 static uint32_t vivint_rabbit_g(uint32_t u, uint32_t v)
 {
     uint64_t sq = u + v;
-    sq = sq * sq;
+    sq          = sq * sq;
     return ((sq >> 32) & 0x00000000ffffffff) ^ (sq & 0x00000000ffffffff);
 }
 
@@ -167,14 +201,14 @@ static uint32_t vivint_rabbit_g(uint32_t u, uint32_t v)
 static void vivint_expand_key(vivint_rabbit_t *g, uint16_t seed)
 {
     uint16_t base = seed ^ 0x0008;
-    g->K[0]        = base;
-    g->K[1]        = (uint16_t)(base + 0x25);
-    g->K[2]        = (uint16_t)(base - 0x04);
-    g->K[3]        = (uint16_t)(base + 0x2c);
-    g->K[4]        = (uint16_t)(base - 0x09);
-    g->K[5]        = (uint16_t)(base - 0x1d);
-    g->K[6]        = base ^ 0x00f9;
-    g->K[7]        = base ^ 0x0022;
+    g->K[0]       = base;
+    g->K[1]       = (uint16_t)(base + 0x25);
+    g->K[2]       = (uint16_t)(base - 0x04);
+    g->K[3]       = (uint16_t)(base + 0x2c);
+    g->K[4]       = (uint16_t)(base - 0x09);
+    g->K[5]       = (uint16_t)(base - 0x1d);
+    g->K[6]       = base ^ 0x00f9;
+    g->K[7]       = base ^ 0x0022;
 }
 
 /* Derives X0..X7 and C0..C7 (RFC 4503 SS2.2) from the 8 seed-expanded words,
@@ -200,53 +234,50 @@ static void vivint_rabbit_key_setup(vivint_rabbit_t *g)
     */
 
     g->b = 0;
-    for (int j = 0u; j < 8; j++)
-    {
-      if (j % 2 == 0)
-      {
-        /* EVEN */
-        g->X[j] = vivint_rabbit_concat(g->K[(j + 1) % 8], g->K[j]);
-        g->C[j] = vivint_rabbit_concat(g->K[(j + 4) % 8], g->K[(j + 5) % 8]);
-      } else {
-        /* ODD */
-        g->X[j] = vivint_rabbit_concat(g->K[(j + 5) % 8], g->K[(j + 4) % 8]);
-        g->C[j] = vivint_rabbit_concat(g->K[j], g->K[(j + 1) % 8]);
-      }
+    for (int j = 0u; j < 8; j++) {
+        if (j % 2 == 0) {
+            /* EVEN */
+            g->X[j] = vivint_rabbit_concat(g->K[(j + 1) % 8], g->K[j]);
+            g->C[j] = vivint_rabbit_concat(g->K[(j + 4) % 8], g->K[(j + 5) % 8]);
+        }
+        else {
+            /* ODD */
+            g->X[j] = vivint_rabbit_concat(g->K[(j + 5) % 8], g->K[(j + 4) % 8]);
+            g->C[j] = vivint_rabbit_concat(g->K[j], g->K[(j + 1) % 8]);
+        }
     }
-
 }
 
 static void vivint_rabbit_update_counters(vivint_rabbit_t *g)
 {
-     /* 2.5.  Counter System
+    /* 2.5.  Counter System
 
-      Before each execution of the next-state function (Section 2.6), the
-      counter system has to be updated.  This system uses constants
-      A1,...,A7, as follows:
+     Before each execution of the next-state function (Section 2.6), the
+     counter system has to be updated.  This system uses constants
+     A1,...,A7, as follows:
 
-      A0 = 0x4D34D34D         A1 = 0xD34D34D3
-      A2 = 0x34D34D34         A3 = 0x4D34D34D
-      A4 = 0xD34D34D3         A5 = 0x34D34D34
-      A6 = 0x4D34D34D         A7 = 0xD34D34D3
+     A0 = 0x4D34D34D         A1 = 0xD34D34D3
+     A2 = 0x34D34D34         A3 = 0x4D34D34D
+     A4 = 0xD34D34D3         A5 = 0x34D34D34
+     A6 = 0x4D34D34D         A7 = 0xD34D34D3
 
-      It also uses the counter carry bit b to update the counter system, as
-      follows:
+     It also uses the counter carry bit b to update the counter system, as
+     follows:
 
-      for j=0 to 7:
-       temp = Cj + Aj + b
-       b    = temp div WORDSIZE
-       Cj   = temp mod WORDSIZE
+     for j=0 to 7:
+      temp = Cj + Aj + b
+      b    = temp div WORDSIZE
+      Cj   = temp mod WORDSIZE
 
-      Note that on exiting this loop, the variable b has to be preserved
-      for the next iteration of the system.  */
+     Note that on exiting this loop, the variable b has to be preserved
+     for the next iteration of the system.  */
 
     const uint32_t A[8] = {0x4D34D34D, 0xD34D34D3, 0x34D34D34, 0x4D34D34D, 0xD34D34D3, 0x34D34D34, 0x4D34D34D, 0xD34D34D3};
 
-    for (int j=0u; j<8; j++)
-    {
+    for (int j = 0u; j < 8; j++) {
         uint64_t temp = (uint64_t)(g->C[j]) + (uint64_t)(A[j]) + (uint64_t)(g->b);
-        g->b = temp / 0x100000000;
-        g->C[j] = temp & 0xffffffff;
+        g->b          = temp / 0x100000000;
+        g->C[j]       = temp & 0xffffffff;
     }
 }
 
@@ -274,9 +305,8 @@ static void vivint_rabbit_next_state(vivint_rabbit_t *g)
     */
 
     uint32_t G[8];
-    for (int j=0u; j<8; j++)
-    {
-      G[j] = vivint_rabbit_g(g->X[j], g->C[j]);
+    for (int j = 0u; j < 8; j++) {
+        G[j] = vivint_rabbit_g(g->X[j], g->C[j]);
     }
 
     // X0 = G0 + (G7 <<< 16) + (G6 <<< 16) mod WORDSIZE
@@ -295,17 +325,14 @@ static void vivint_rabbit_next_state(vivint_rabbit_t *g)
     g->X[6] = G[6] + vivint_rotl32(G[5], 16) + vivint_rotl32(G[4], 16);
     // X7 = G7 + (G6 <<<  8) +  G5         mod WORDSIZE
     g->X[7] = G[7] + vivint_rotl32(G[6], 8) + G[5];
-
 }
 
 static void vivint_rabbit_reinitialize_counters(vivint_rabbit_t *g)
 {
-    for (int j = 0u; j < 8; j++)
-    {
-      g->C[j] ^= g->X[(j+4) % 8];
+    for (int j = 0u; j < 8; j++) {
+        g->C[j] ^= g->X[(j + 4) % 8];
     }
 }
-
 
 /* Reduced extraction: RFC 4503 SS2.7 derives a full 128 bit block; this
    protocol only needs the status keystream byte (c1) and the auth byte
@@ -335,19 +362,17 @@ static void vivint_rabbit_extract(vivint_rabbit_t *g)
     g->S[6] = (g->X[6] & 0xffff) ^ ((g->X[3] >> 16) & 0xffff);
     //    S[127..112] = X6[31..16] ^ X1[15..0]
     g->S[7] = ((g->X[6] >> 16) & 0xffff) ^ (g->X[1] & 0xffff);
-
 }
 
-// Generate the 48 bytes of cipher given a specific key
-// out should be a uint8_t[48]
+/* Generate the 48 bytes of cipher given a specific key
+   out should be a uint8_t[48] */
 static void vivint_rabbit_gen_cipher(vivint_rabbit_t *g, uint8_t *out)
 {
 
     vivint_rabbit_key_setup(g);
 
     // Iterate 4 times before extracting secrets
-    for (int i=0; i < 4; i++)
-    {
+    for (int i = 0; i < 4; i++) {
         vivint_rabbit_update_counters(g);
         vivint_rabbit_next_state(g);
     }
@@ -356,15 +381,13 @@ static void vivint_rabbit_gen_cipher(vivint_rabbit_t *g, uint8_t *out)
 
     // Now we pull out all 48 bytes of data for the cipher
     // auto out = ret.begin();
-    for (int i=0; i<3; i++)
-    {
+    for (int i = 0; i < 3; i++) {
 
         vivint_rabbit_update_counters(g);
         vivint_rabbit_next_state(g);
         vivint_rabbit_extract(g);
 
-        for (int j = 0; j < 8; j++)
-        {
+        for (int j = 0; j < 8; j++) {
             *out = g->S[j] & 0x00ff;
             out++;
             *out = (g->S[j] >> 8) & 0x00ff;
@@ -373,21 +396,24 @@ static void vivint_rabbit_gen_cipher(vivint_rabbit_t *g, uint8_t *out)
     }
 }
 
-// Customization to the rabbit cipher that modifies the 128bit key based on the packet counter
+/* Customization to the rabbit cipher that modifies the 128bit key based on the packet counter
+ * This makes the key seem like it is more than 16 bits */
 static void vivint_gen_rabbit_key(vivint_rabbit_t *g, uint16_t seed, uint16_t counter)
 {
     uint16_t i = 24;
-    do
-    {
-        if (i > 0xfff7) { i = 0; }
-        if (i == 24) { vivint_expand_key(g, seed); }
-        int mod = i % 7;
-        g->K[mod] =  i + mod + g->K[mod];
-        g->K[7] = g->K[7] ^ mod;
-        i+=12;
-    } while(i <= counter);
+    do {
+        if (i > 0xfff7) {
+            i = 0;
+        }
+        if (i == 24) {
+            vivint_expand_key(g, seed);
+        }
+        int mod   = i % 7;
+        g->K[mod] = i + mod + g->K[mod];
+        g->K[7]   = g->K[7] ^ mod;
+        i += 12;
+    } while (i <= counter);
 }
-
 
 /* Per-device decode state: advanced incrementally as packets with
    increasing counters arrive, re-synced from the entry counter on a
@@ -469,11 +495,10 @@ static r_device *vivint_create(char const *args)
         unsigned p1;
         unsigned p2;
         unsigned seed;
-        if (ctx->count < VIVINT_MAX_SENSORS
-                && sscanf(tok, "%u-%u=%x", &p1, &p2, &seed) == 3) {
+        if (ctx->count < VIVINT_MAX_SENSORS && sscanf(tok, "%u-%u=%x", &p1, &p2, &seed) == 3) {
             vivint_sensor_t *s = &ctx->sensors[ctx->count++];
-            s->id            = ((p1 & 0xfff) << 20) | (p2 & 0xfffff);
-            s->seed          = (uint16_t)seed;
+            s->id              = ((p1 & 0xfff) << 20) | (p2 & 0xfffff);
+            s->seed            = (uint16_t)seed;
         }
         tok = vivint_strtok(NULL, ",", &saveptr);
     }
@@ -482,19 +507,19 @@ static r_device *vivint_create(char const *args)
     return dev;
 }
 
+// Generates the cipher values given a specific seed and counter
 static void vivint_rabbit_advance_cipher(vivint_sensor_t *s, uint16_t counter)
 {
     // Need to check to see if we need to regenerate our cipher output
     int diff = counter - s->last_counter;
     if ((s->last_counter == 0xffff) ||
-        (counter % 12 == 0) || (diff > 12) || (diff < -12) ||
-        (counter % 12 < s->last_counter % 12))
-    {
-      // We need to regenerate
-      // Could make static to take it off of the stack
-      vivint_rabbit_t rabbit;
-      vivint_gen_rabbit_key(&rabbit, s->seed, counter);
-      vivint_rabbit_gen_cipher(&rabbit, s->cipher);
+            (counter % 12 == 0) || (diff > 12) || (diff < -12) ||
+            (counter % 12 < s->last_counter % 12)) {
+        // We need to regenerate
+        // Could make static to take it off of the stack
+        vivint_rabbit_t rabbit;
+        vivint_gen_rabbit_key(&rabbit, s->seed, counter);
+        vivint_rabbit_gen_cipher(&rabbit, s->cipher);
     }
     s->last_counter = counter;
 }
@@ -502,8 +527,8 @@ static void vivint_rabbit_advance_cipher(vivint_sensor_t *s, uint16_t counter)
 /* The other 4 bits of bytes 8 and 9 in the data contain 4 bits of the raw cipher data xor'd with 0x10 */
 static int vivint_validate_rabbit_nibble(vivint_sensor_t *s, uint8_t check, uint16_t counter)
 {
-    int mod = counter % 12;
-    uint8_t mac_byte = s->cipher[mod*4 + 2] & 0xf0;
+    int mod          = counter % 12;
+    uint8_t mac_byte = s->cipher[mod * 4 + 2] & 0xf0;
 
     return mac_byte == (check ^ 0x10);
 }
@@ -513,7 +538,7 @@ static int vivint_decrypt_flags(vivint_sensor_t *s, int flags, uint16_t counter)
 {
     int mod = counter % 12;
 
-    int decrypt_byte = s->cipher[mod*4];
+    int decrypt_byte = s->cipher[mod * 4];
 
     // The last 2 bits are always 0 in encrypted messages
     return (flags ^ decrypt_byte) & 0xfc;
@@ -522,22 +547,18 @@ static int vivint_decrypt_flags(vivint_sensor_t *s, int flags, uint16_t counter)
 /* Iterates through cached data from a sensor to determine the seed */
 static int vivint_determine_seed(r_device *decoder, vivint_sensor_t *s)
 {
-    int num_matches = 0;
+    int num_matches       = 0;
     uint16_t matched_seed = 0xffff;
-    for (uint16_t seed = 1; seed < 0xffff; seed++)
-    {
+    for (uint16_t seed = 1; seed < 0xffff; seed++) {
         s->last_counter = 0xffff;
-        for (int i = 0; i < VIVINT_SEED_DATA_REQUIRED; i++)
-        {
+        for (int i = 0; i < VIVINT_SEED_DATA_REQUIRED; i++) {
             int idx = (s->counter_idx - VIVINT_SEED_DATA_REQUIRED + i) % VIVINT_CACHED_COUNTERS;
             s->seed = seed;
             vivint_rabbit_advance_cipher(s, s->counters[idx]);
-            if (!vivint_validate_rabbit_nibble(s, s->cipher_cache[idx], s->counters[idx]))
-            {
+            if (!vivint_validate_rabbit_nibble(s, s->cipher_cache[idx], s->counters[idx])) {
                 break;
             }
-            if (i == VIVINT_SEED_DATA_REQUIRED - 1)
-            {
+            if (i == VIVINT_SEED_DATA_REQUIRED - 1) {
                 matched_seed = seed;
                 num_matches++;
             }
@@ -546,19 +567,18 @@ static int vivint_determine_seed(r_device *decoder, vivint_sensor_t *s)
 
     s->seed_matches = num_matches;
 
-    if (num_matches == 1)
-    {
+    if (num_matches == 1) {
         decoder_logf(decoder, 1, __func__, "Determined seed: %x", (unsigned)matched_seed);
         s->seed = matched_seed;
         // Reset the last counter so it regenerates the cipher with the new key
         s->last_counter = 0xffff;
         vivint_rabbit_advance_cipher(s, s->counters[(s->counter_idx - 1) % VIVINT_CACHED_COUNTERS]);
         return 1;
-    } else {
+    }
+    else {
         s->seed = 0xffff;
         return 0;
     }
-
 }
 
 static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
@@ -585,11 +605,11 @@ static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     bitbuffer_extract_bytes(bitbuffer, row, pos, b, VIVINT_MSG_BIT_LEN);
     decoder_log_bitrow(decoder, 2, __func__, b, VIVINT_MSG_BIT_LEN, "MSG (inverted, aligned)");
 
-    int event_type  = b[0];
-    int counter     = (b[1] << 8) | b[2];
-    int flags       = b[3];
-    unsigned id     = ((unsigned)b[4] << 24) | ((unsigned)b[5] << 16) | ((unsigned)b[6] << 8) | b[7];
-    int crc         = (b[8] << 8) | b[9];
+    int event_type    = b[0];
+    int counter       = (b[1] << 8) | b[2];
+    int flags         = b[3];
+    unsigned id       = ((unsigned)b[4] << 24) | ((unsigned)b[5] << 16) | ((unsigned)b[6] << 8) | b[7];
+    int crc           = (b[8] << 8) | b[9];
     int cipher_nibble = b[8] & 0xf0;
 
     if (id == 0 || id == 0xffffffff) {
@@ -599,17 +619,31 @@ static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
 
     int crc_valid = 0;
     // TODO add the other packet types that don't use the 12bit crc
-    if (event_type == 0xd0) {
-        if (crc == crc16(b, 8, 0x8050, 0)) crc_valid = 1;
-    }
-    else {
+
+    switch (event_type) {
+    case VIVINT_PACKET_EVENT_DW:
+    case VIVINT_PACKET_EVENT_GB:
+    case VIVINT_PACKET_EVENT_PIR:
+        // These packets are similar to the EVENT packets, but have a multiple of 797 in the high nibble
+    case VIVINT_PACKET_BATTERY:
+    case VIVINT_PACKET_SEED:
+    case VIVINT_PACKET_MFG_BOOT: {
         uint8_t b8_full = b[8];
         b[8] &= 0xF0;
         int crc_full = crc16(b, 9, 0x8050, 0);
         b[8]         = b8_full;
         int check12  = crc_full >> 4;
         int stored12 = ((b8_full & 0x0F) << 8) | b[9];
-        if (check12 == stored12) crc_valid = 1;
+        if (check12 == stored12)
+            crc_valid = 1;
+        break;
+    }
+
+    case VIVINT_PACKET_STARTUP:
+    default:
+        if (crc == crc16(b, 8, 0x8050, 0))
+            crc_valid = 1;
+        break;
     }
 
     if (!crc_valid) {
@@ -620,54 +654,72 @@ static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     char id_str[13];
     snprintf(id_str, sizeof(id_str), "%04u-%07u", (id >> 20) & 0xfff, id & 0xfffff);
 
-    int has_valid_flags  = 0;
-    uint16_t seed        = 0xffff;
-    int seed_data_count  = 0;
-    int seed_matches     = -1;
+    int has_valid_flags       = 0;
+    int has_startup_data      = 0;
+    uint16_t seed             = 0xffff;
+    int seed_data_count       = 0;
+    int seed_matches          = -1;
     char const *decode_status = "unsupported_event_type";
 
-    int loop1_bit       = 0;    // Loop 1, PIR motion, external contact for DW11, and reed for DW21R
-    int tamper_bit      = 0;    // Case open tamper
-    int loop2_bit       = 0;    // Loop 2, or reed for DW11
-    int alarm_bit       = 0;    // Unused
-    int battery_low_bit = 0;    // Tested
-    int heartbeat_bit   = 0;    // Bit that toggles at a timed interval based on sum of 797
+    int loop1_bit       = 0; // Loop 1, PIR motion, external contact for DW11, and reed for DW21R
+    int tamper_bit      = 0; // Case open tamper
+    int loop2_bit       = 0; // Loop 2, or reed for DW11
+    int alarm_bit       = 0; // Unused
+    int battery_low_bit = 0; // Tested
+    int heartbeat_bit   = 0; // Bit that toggles at a timed interval based on sum of 797
 
-    // TODO: Should work on other packets as well.
-    if (event_type == 0x7a || event_type == 0x74 || event_type == 0x79) {
+    int battery_level     = 0; // Reported raw battery level
+    int battery_threshold = 0; // Threshold given that corresponds to the battery level for a low battery event
+
+    // While the event can give a class of device, the 0xd0 message
+    // can tell us exactly which device it is
+    const char *model = "Vivint Security";
+
+    // Add event types here for other devices
+    if (event_type == VIVINT_PACKET_EVENT_DW || event_type == VIVINT_PACKET_EVENT_GB || event_type == VIVINT_PACKET_EVENT_PIR) {
+
+        switch (event_type) {
+        case VIVINT_PACKET_EVENT_DW:
+            model = "Vivint Security V-DW11-345/V-DW21R-345";
+            break;
+        case VIVINT_PACKET_EVENT_PIR:
+            model = "Vivint Security V-PIR2-345/V-PIR3-345";
+            break;
+        case VIVINT_PACKET_EVENT_GB:
+            model = "Vivint Security V-GB2-345/V-GB3-345";
+            break;
+        default:
+            break;
+        }
 
         // TODO Should check bit 1 of the event data to see if this packet is encrypted
         vivint_sensor_t *s = vivint_ctx_find((vivint_ctx_t *)decoder_user_data(decoder), id);
 
         // If we don't know about this TXID, let's add it to our list if we have room and try to crack the seed
-        if (!s)
-        {
+        if (!s) {
             vivint_ctx_t *ctx = (vivint_ctx_t *)decoder_user_data(decoder);
             if (ctx->count < VIVINT_MAX_SENSORS) {
-                s = &ctx->sensors[ctx->count++];
-                s->id            = id;
-                s->seed          = 0xffff;
-                s->last_counter  = 0xffff;
-                s->counter_idx   = 0;
-                s->seed_matches  = -1;
+                s               = &ctx->sensors[ctx->count++];
+                s->id           = id;
+                s->seed         = 0xffff;
+                s->last_counter = 0xffff;
+                s->counter_idx  = 0;
+                s->seed_matches = -1;
             }
         }
         if (s) {
             decode_status = "collecting_seed";
             // Let's see if we can determine the seed
-            if (s->seed == 0xffff || s->seed == 0x0000)
-            {
+            if (s->seed == 0xffff || s->seed == 0x0000) {
                 // Store the data we need to determine the seed
                 // Prevent duplicates
-                if (counter != s->last_counter)
-                {
-                    int idx = s->counter_idx % VIVINT_CACHED_COUNTERS;
+                if (counter != s->last_counter) {
+                    int idx              = s->counter_idx % VIVINT_CACHED_COUNTERS;
                     s->cipher_cache[idx] = cipher_nibble;
-                    s->counters[idx] = counter;
+                    s->counters[idx]     = counter;
                     s->counter_idx++;
                     // Check if we have enough data to determine the seed
-                    if (s->counter_idx >= VIVINT_SEED_DATA_REQUIRED)
-                    {
+                    if (s->counter_idx >= VIVINT_SEED_DATA_REQUIRED) {
                         decoder_logf(decoder, 1, __func__, "Attempting to crack seed");
                         vivint_determine_seed(decoder, s);
                     }
@@ -675,16 +727,14 @@ static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 s->last_counter = counter;
             }
 
-            if (s->seed != 0xffff && s->seed != 0x0000)
-            {
+            if (s->seed != 0xffff && s->seed != 0x0000) {
                 // This is where we try to decode the message
                 // We also need to check the high nibble of byte 8 to check if
                 // the cipher is correct
                 vivint_rabbit_advance_cipher(s, counter);
-                if (vivint_validate_rabbit_nibble(s, cipher_nibble, counter))
-                {
-                    has_valid_flags  = 1;
-                    flags = vivint_decrypt_flags(s, flags, counter);
+                if (vivint_validate_rabbit_nibble(s, cipher_nibble, counter)) {
+                    has_valid_flags = 1;
+                    flags           = vivint_decrypt_flags(s, flags, counter);
                     /* Extract DW11 event bits (CTRABHEZ layout):
                        C=contact(7), T=tamper(6), R=reed(5), A=alarm(4),
                        B=battery_low(3), H=heartbeat(2), E=Encrypted(1),
@@ -695,14 +745,15 @@ static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                     alarm_bit       = flags & 0x10 ? 1 : 0;
                     battery_low_bit = flags & 0x08 ? 1 : 0;
                     heartbeat_bit   = flags & 0x04 ? 1 : 0;
-                } else {
+                }
+                else {
                     decode_status = "cipher_check_failed";
                     decoder_logf(decoder, 2, __func__, "Invalid Rabbit cipher check nibble");
                 }
             }
-            seed = s->seed;
+            seed            = s->seed;
             seed_data_count = s->counter_idx < VIVINT_CACHED_COUNTERS ? s->counter_idx : VIVINT_CACHED_COUNTERS;
-            seed_matches = s->seed_matches;
+            seed_matches    = s->seed_matches;
             if (has_valid_flags) {
                 decode_status = "decoded";
             }
@@ -712,32 +763,39 @@ static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
                 else if (seed_matches > 1)
                     decode_status = "seed_ambiguous";
             }
-        } else {
+        }
+        else {
             decode_status = "sensor_cache_full";
         }
+    }
+    else if (event_type == VIVINT_PACKET_STARTUP) {
+        //
+        has_startup_data = 1;
+        int device_type  = b[2];
+        switch (device_type) {
+        case VIVINT_DEVICE_TYPE_V_DW11_345:
+            model = "Vivint Security V-DW11-345";
+            break;
+        case VIVINT_DEVICE_TYPE_V_DW21R_345:
+            model = "Vivint Security V-DW21R-345";
+            break;
+        case VIVINT_DEVICE_TYPE_V_GB2_345:
+            model = "Vivint Security V-GB2-345";
+            break;
+        case VIVINT_DEVICE_TYPE_V_PIR2_345:
+            model = "Vivint Security V-PIR2-345";
+            break;
+        default:
+            break;
+        }
+        battery_level = (b[1] << 8) | b[3];
+    } else if (event_type = VIVINT_PACKET_BATTERY) {
     }
 
     char payload[21];
     if (!has_valid_flags) {
         for (int i = 0; i < 10; ++i)
             snprintf(&payload[i * 2], 3, "%02x", b[i]);
-    }
-
-    // TODO move this somewhere more appropriate
-    const char* model = "Vivint-Security";
-    switch (event_type)
-    {
-        case VIVINT_EVENT_DW:
-            model = "Vivint-Security DW11 or DW21R";
-            break;
-        case VIVINT_EVENT_PIR:
-            model = "Vivint-Security PIR2";
-            break;
-        case VIVINT_EVENT_GB:
-            model = "Vivint-Security GB";
-            break;
-        default:
-            break;
     }
 
 #if OUTPUT_VIVINT_DECODE
@@ -749,12 +807,11 @@ static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
     (void)decode_status;
 #endif
 
-    // TODO change the model to match the device type
     /* clang-format off */
     data_t *data = data_make(
             "model",        "",              DATA_STRING, model,
             "id",           "",              DATA_STRING, id_str,
-            "counter",      "",              DATA_FORMAT, "%04x", DATA_INT, counter,
+            "counter",      "",              DATA_COND, has_valid_flags, DATA_FORMAT, "%04x", DATA_INT, counter,
 #if OUTPUT_VIVINT_DECODE
             "seed",         "",              DATA_COND, seed != 0xffff && seed != 0x0000, DATA_STRING, seed_str,
             "decode_status", "Decode status", DATA_STRING, decode_status,
@@ -762,7 +819,7 @@ static int vivint_decode(r_device *decoder, bitbuffer_t *bitbuffer)
             "seed_data_required", "Seed samples required", DATA_COND, seed == 0xffff || seed == 0x0000, DATA_INT, VIVINT_SEED_DATA_REQUIRED,
             "seed_candidate_count", "Seed candidates", DATA_COND, (seed == 0xffff || seed == 0x0000) && seed_matches >= 0, DATA_INT, seed_matches,
 #endif
-            "flags",        "",              DATA_FORMAT, "%02x", DATA_INT, flags,
+            "flags",        "",              DATA_COND, has_valid_flags, DATA_FORMAT, "%02x", DATA_INT, flags,
             "event_type",   "",              DATA_FORMAT, "%02x", DATA_INT, event_type,
             "state",        "",              DATA_COND, has_valid_flags,  DATA_STRING, loop1_bit ? "open" : "closed",
             "loop1",        "",              DATA_COND, has_valid_flags,  DATA_INT,     loop1_bit,
@@ -806,11 +863,11 @@ static char const *const output_fields[] = {
 };
 
 r_device const vivint = {
-        .name        = "Vivint Door/Window Sensor, V-DW21R-345/V-DW11-345",
+        .name        = "Vivint 345MHz Sensors, V-DW11-345/V-DW21R-345, V-GB2-345/V-GB3-345, V-PIR2-345/V-PIR3-345",
         .modulation  = OOK_PULSE_MANCHESTER_ZEROBIT,
         .short_width = 150,
         .long_width  = 0,
-        .reset_limit = 400,
+        .reset_limit = 300,
         .decode_fn   = &vivint_decode,
         .create_fn   = &vivint_create,
         .fields      = output_fields,


### PR DESCRIPTION
**Improves CC1101 Vivint reception**

- Refreshes Vivint decoder to latest version
- Adds tested Vivint profile: 345.00 MHz / 162.5 kHz / 0x84 / 0x40 / 0xA0
- Expands Vivint device identification and startup/battery decoding
- Adds counter-continuity testing and extended CC1101 tuning examples
- Documents 345 MHz antenna tuning
- Confirms the 433.92 MHz profile remains 433.920 MHz / 203.125 kHz / 0xC7 / 0x40 / 0x93
- Updates the RadioLib dependency to 7.7.1