### PR TITLE
Add support for a second CC1101 receive channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
         environment:
           - esp32_lilygo
           - esp32_cc1101
+          - esp32_cc1101_dual
           - esp32_cc1101_FSK
           - esp32c3_cdc_cc1101
     steps:

--- a/examples/OOK_Receiver/OOK_Receiver.ino
+++ b/examples/OOK_Receiver/OOK_Receiver.ino
@@ -28,6 +28,16 @@
 #  define RF_MODULE_FREQUENCY 433.92
 #endif
 
+// Dual-receiver builds (RF_MODULE2_* build flags, see the esp32_cc1101_dual
+// environment): the second CC1101 listens on its own frequency and decodes
+// through the same pipeline. Decoded messages carry an "mhz" field naming
+// the channel they arrived on.
+#ifdef RF_DUAL_CC1101
+#  ifndef RF_MODULE2_FREQUENCY
+#    define RF_MODULE2_FREQUENCY 915.00
+#  endif
+#endif
+
 #define JSON_MSG_BUFFER            512
 #define RAW_CALLBACK_SAMPLE_PULSES 8
 
@@ -532,6 +542,16 @@ void setup() {
   Log.notice(F("****** setup ******" CR));
   rf.initReceiver(RF_MODULE_RECEIVER_GPIO, RF_MODULE_FREQUENCY);
   Log.notice(F("RF_MODULE_FREQUENCY %F" CR), (double)RF_MODULE_FREQUENCY);
+#ifdef RF_DUAL_CC1101
+  // Must run after initReceiver() (shared SPI bus + receiver task) and
+  // before enableReceiver() (which attaches both channels' interrupts).
+  if (rf.initSecondaryReceiver(RF_MODULE2_RECEIVER_GPIO,
+                               RF_MODULE2_FREQUENCY)) {
+    Log.notice(F("RF_MODULE2_FREQUENCY %F" CR), (double)RF_MODULE2_FREQUENCY);
+  } else {
+    Log.error(F("Second receive channel disabled (init failed)" CR));
+  }
+#endif
   rf.setCallback(rtl_433_Callback, messageBuffer, JSON_MSG_BUFFER);
 #if defined(CC1101_OOK_TUNING)
   rf.setRawPulsesCallback(rtl_433_RawCallback);

--- a/examples/OOK_Receiver/README.md
+++ b/examples/OOK_Receiver/README.md
@@ -34,6 +34,35 @@ build_flags =
 
 See the `esp32_heltec_915` environment in `platformio.ini` for a complete 915 MHz configuration example.
 
+# Dual CC1101 Receivers
+
+Two CC1101 modules sharing one SPI bus can receive on two frequencies at the
+same time — for example 433.92 MHz on the primary radio and 915 MHz on the
+second. The second radio is a receive-only channel that decodes through the
+same pipeline, and every decoded message carries an `"mhz"` field naming the
+channel it arrived on.
+
+Enable it with the `RF_MODULE2_*` build flags (each module needs its own CSN
+and GDO pins; MOSI/MISO/SCK are shared, and the shared-SPI pin set must be
+explicit):
+
+```ini
+build_flags =
+  '-DRF_MODULE_SCK=18'
+  '-DRF_MODULE_MISO=19'
+  '-DRF_MODULE_MOSI=23'
+  '-DRF_MODULE_CS=5'
+  '-DRF_MODULE2_CS=27'
+  '-DRF_MODULE2_GDO0=25'
+  '-DRF_MODULE2_GDO2=26'
+  '-DRF_MODULE2_FREQUENCY=915.00'
+```
+
+See the `esp32_cc1101_dual` environment in `platformio.ini` for the complete
+configuration. The second channel is started from the sketch with
+`initSecondaryReceiver()` and can be retuned at runtime with
+`setSecondaryFrequency()`.
+
 # Transceiver Module Wiring
 
 ## CC1101 Transceiver Module

--- a/examples/OOK_Receiver/platformio.ini
+++ b/examples/OOK_Receiver/platformio.ini
@@ -113,6 +113,27 @@ monitor_speed = 921600
 upload_port = /dev/cu.usbserial-0001
 upload_speed = 921600
 
+; Dual-receiver OOK build: two CC1101s share one SPI bus. The second radio is
+; an additional receive-only channel on its own frequency (915 MHz here, with
+; the primary on 433.92), decoding through the same pipeline; every decoded
+; message carries an "mhz" field naming the channel it arrived on. The
+; RF_MODULE2_* support requires the shared-SPI pin set to be explicit, so the
+; ESP32 VSPI defaults are spelled out below.
+[env:esp32_cc1101_dual]
+extends = env:esp32_cc1101
+build_flags =
+  ${env:esp32_cc1101.build_flags}
+; *** shared SPI bus (explicit VSPI defaults) ***
+  '-DRF_MODULE_SCK=18'
+  '-DRF_MODULE_MISO=19'
+  '-DRF_MODULE_MOSI=23'
+  '-DRF_MODULE_CS=5'
+; *** second CC1101: receive channel 2 ***
+  '-DRF_MODULE2_CS=27'    ; second CC1101 chip select
+  '-DRF_MODULE2_GDO0=25'  ; second CC1101 GDO0 (data input for channel 2)
+  '-DRF_MODULE2_GDO2=26'  ; second CC1101 GDO2
+  '-DRF_MODULE2_FREQUENCY=915.00' ; second channel's receive frequency
+
 ; Installation-specific profile selected by the 2026-08-26 RTL-SDR-backed
 ; 433.92 MHz tuning run. Keep separate from the portable library defaults.
 [env:esp32_cc1101_43392_tuned]

--- a/src/rtl_433/r_api.c
+++ b/src/rtl_433/r_api.c
@@ -979,6 +979,17 @@ void data_acquired_handler(r_device* r_dev, data_t* data) {
               DATA_INT, cfg->demod->pulse_data.signalRssi, "duration", "",
               DATA_INT, cfg->demod->pulse_data.signalDuration, "time_ms", "",
               DATA_INT, (int)rtl_433_millis(), NULL);
+  // On a multi-radio receiver the capture path stamps each pulse train with
+  // the frequency its radio was tuned to; pass it through so a decode can be
+  // attributed to the channel it arrived on. Zero means "not stamped".
+  // Rounded to 10 kHz: the stamp travels as a single-precision float and
+  // 433.92f would otherwise serialise as 433.9199829.
+  if (cfg->demod->pulse_data.centerfreq_hz > 0) {
+    double mhz =
+        (double)((long)(cfg->demod->pulse_data.centerfreq_hz / 10000.0f + 0.5f)) /
+        100.0;
+    data_append(data, "mhz", "", DATA_DOUBLE, mhz, NULL);
+  }
   if (!cfg->callback || !cfg->messageBuffer || cfg->bufferSize <= 0) {
     data_free(data);
     return;

--- a/src/rtl_433_ESP.cpp
+++ b/src/rtl_433_ESP.cpp
@@ -55,6 +55,10 @@ SX1278 radio = RADIO_LIB_MODULE;
 CC1101 radio = RADIO_LIB_MODULE;
 #endif
 
+#ifdef RF_DUAL_CC1101
+CC1101 radio2 = RADIO_LIB_MODULE2;
+#endif
+
 #if defined(RF_SX1276) || defined(RF_SX1278)
 uint8_t rtl_433_ESP::OokFixedThreshold = OOK_FIXED_THRESHOLD;
 #endif
@@ -173,6 +177,76 @@ static portMUX_TYPE captureMux = portMUX_INITIALIZER_UNLOCKED;
 static bool initialized = false;
 static rtl_433_ESPError initializationError = rtl_433_ESPError::None;
 
+float rtl_433_ESP::receiveFrequencyMhz = 0;
+
+// Serialises SPI access between the receiver task (RSSI polling on its own
+// core) and every other context that touches a radio register (transmit
+// handover, retuning, the hourly deaf workaround). Created by initReceiver();
+// spiTake()/spiGive() degrade to no-ops before that.
+static SemaphoreHandle_t _spiMutex = NULL;
+
+bool rtl_433_ESP::spiTake(uint32_t waitMs) {
+  if (_spiMutex == NULL) {
+    return true;
+  }
+  TickType_t ticks =
+      (waitMs == UINT32_MAX) ? portMAX_DELAY : pdMS_TO_TICKS(waitMs);
+  return xSemaphoreTake(_spiMutex, ticks) == pdTRUE;
+}
+
+void rtl_433_ESP::spiGive() {
+  if (_spiMutex != NULL) {
+    xSemaphoreGive(_spiMutex);
+  }
+}
+
+#ifdef RF_DUAL_CC1101
+
+/*----------------------------- Second receive channel -----------------------------*/
+// Mirrors the primary channel's capture state one-for-one. Kept as a parallel
+// set of statics rather than folding both channels into a struct so the
+// hardware-proven primary path is not disturbed; the receiver task interleaves
+// the two channels, and completed trains from either feed the same decoder
+// queue, distinguished by pulse_data_t.centerfreq_hz.
+
+int rtl_433_ESP::messageCount2 = 0;
+int rtl_433_ESP::currentRssi2 = 0;
+int rtl_433_ESP::signalRssi2 = 0;
+int rtl_433_ESP::rssiThreshold2 = MINRSSI;
+int rtl_433_ESP::averageRssi2 = 0;
+
+static pulse_data_t* _pulseTrains2 = NULL;
+static bool _enabledReceiver2 = false;
+static bool receiveMode2 = false;
+static volatile uint8_t _actualPulseTrain2 = 0;
+static uint8_t _avaiablePulseTrain2 = 0;
+static volatile unsigned long _lastChange2 = 0;
+static volatile int16_t _nrpulses2 = 0;
+static int8_t receiverGpio2 = -1;
+static float _freq2Mhz = 0;
+
+static unsigned long signalStart2 = 0;
+static unsigned long signalEnd2 = 0;
+static unsigned long gapStart2 = 0;
+
+static int _totalRssi2 = 0;
+static int _rssiCount2 = 0;
+static int _peakRssi2 = -256;
+static int _aboveThreshold2 = 0;
+static int _noiseCount2 = 0;
+#  ifdef AUTORSSITHRESHOLD
+static bool _rssiCalibrated2 = false;
+#  endif
+
+#  if PRETRIGGER_ENABLED
+static volatile unsigned int _pretriggerPulse2[PRETRIGGER_PAIRS];
+static volatile unsigned int _pretriggerGap2[PRETRIGGER_PAIRS];
+static volatile uint8_t _pretriggerHead2 = 0;
+static volatile uint8_t _pretriggerCount2 = 0;
+static volatile unsigned int _pretriggerPendingPulse2 = 0;
+#  endif
+#endif
+
 /*----------------------------- End of variable initialization -----------------------------*/
 
 rtl_433_ESP::rtl_433_ESP() {}
@@ -196,8 +270,13 @@ bool rtl_433_ESP::begin(byte inputPin, float receiveFrequency) {
     return false;
   }
   if (!_pulseTrains) {
+    // MALLOC_CAP_8BIT is load-bearing: INTERNAL alone may satisfy a large
+    // allocation from the IRAM heap, which only tolerates aligned 32-bit
+    // accesses — the byte-wise memcpy of a train (and FPU stores into it)
+    // then raise LoadStoreError. 8BIT restricts the allocation to DRAM.
     _pulseTrains = static_cast<pulse_data_t*>(heap_caps_calloc(
-        RECEIVER_BUFFER_SIZE, sizeof(pulse_data_t), MALLOC_CAP_INTERNAL));
+        RECEIVER_BUFFER_SIZE, sizeof(pulse_data_t),
+        MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
   }
   if (!_pulseTrains) {
     initializationError = rtl_433_ESPError::OutOfMemory;
@@ -209,6 +288,7 @@ bool rtl_433_ESP::begin(byte inputPin, float receiveFrequency) {
 #endif
 
   receiverGpio = digitalPinToInterrupt(inputPin);
+  receiveFrequencyMhz = receiveFrequency;
 #ifdef MEMORY_DEBUG
   logprintfLn(LOG_INFO, "Pre initReceiver: %d", ESP.getFreeHeap());
 #endif
@@ -388,6 +468,14 @@ bool rtl_433_ESP::begin(byte inputPin, float receiveFrequency) {
 #endif
   RADIOLIB_STATE(state, "receiveDirect");
 
+#if defined(RF_CC1101) && defined(CC1101_DATA_ON_GDO2)
+  // RadioLib routes async serial data to GDO0 only. Mirror it onto GDO2
+  // (IOCFG2 = 0x0D, serial data output) so boards that cannot use GDO0 as an
+  // input can receive on GDO2. Additive: GDO0 keeps its configuration.
+  state = radio.SPIsetRegValue(RADIOLIB_CC1101_REG_IOCFG2, 0x0D);
+  RADIOLIB_STATE(state, "IOCFG2 serial data out (GDO2)");
+#endif
+
 #ifdef RESOURCE_DEBUG
   logprintfLn(LOG_INFO, "rtl_433_ReceiverTask_Stack %d", rtl_433_ReceiverTask_Stack);
 #endif
@@ -395,6 +483,10 @@ bool rtl_433_ESP::begin(byte inputPin, float receiveFrequency) {
 #ifdef RF_MODULE_INIT_STATUS
   getModuleStatus();
 #endif
+
+  if (_spiMutex == NULL) {
+    _spiMutex = xSemaphoreCreateMutex();
+  }
 
   if (!rtl_433_ReceiverHandle) {
     BaseType_t taskCreated = xTaskCreatePinnedToCore(
@@ -420,6 +512,189 @@ bool rtl_433_ESP::begin(byte inputPin, float receiveFrequency) {
   initializationError = rtl_433_ESPError::None;
   return true;
 }
+
+#ifdef RF_DUAL_CC1101
+/**
+ * @brief Initialize the second CC1101 as an additional receive channel.
+ * Must run after initReceiver(): the shared SPI bus is begun there and the
+ * receiver task this channel rides in is spawned there.
+ */
+bool rtl_433_ESP::initSecondaryReceiver(byte inputPin, float receiveFrequency) {
+  if (_pulseTrains2 == NULL) {
+    _pulseTrains2 = (pulse_data_t*)heap_caps_calloc(
+        RECEIVER_BUFFER_SIZE, sizeof(pulse_data_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+  }
+  if (_pulseTrains2 == NULL) {
+    // Leave the channel disabled: receiverGpio2 stays -1, so neither
+    // enableReceiver() nor the receiver task ever touches it.
+    initializationError = rtl_433_ESPError::OutOfMemory;
+    logprintfLn(LOG_ERR,
+                STR_MODULE
+                " channel 2 disabled: no memory for pulse-train "
+                "buffers");
+    return false;
+  }
+
+  receiverGpio2 = digitalPinToInterrupt(inputPin);
+  _freq2Mhz = receiveFrequency;
+
+  for (unsigned int i = 0; i < RECEIVER_BUFFER_SIZE; i++) {
+    _pulseTrains2[i].num_pulses = 0;
+  }
+  _avaiablePulseTrain2 = 0;
+  _actualPulseTrain2 = 0;
+  _nrpulses2 = 0;
+  receiveMode2 = false;
+#  if PRETRIGGER_ENABLED
+  _pretriggerHead2 = 0;
+  _pretriggerCount2 = 0;
+  _pretriggerPendingPulse2 = 0;
+#  endif
+
+#  ifdef DEMOD_DEBUG
+  logprintfLn(LOG_INFO, STR_MODULE " channel 2 gpio receive pin: %d", inputPin);
+  logprintfLn(LOG_INFO, STR_MODULE " channel 2 receive frequency: %f",
+              receiveFrequency);
+#  endif
+
+  spiTake(portMAX_DELAY);
+  // RADIOLIB_STATE reports failures through rtl_433_radio_config_failed;
+  // borrow the flag for this channel's configuration and put the primary's
+  // verdict back afterwards, so a channel-2 failure disables channel 2
+  // without rewriting history for begin().
+  bool priorRadioFailure = rtl_433_radio_config_failed;
+  rtl_433_radio_config_failed = false;
+
+  int state = radio2.begin();
+  RADIOLIB_STATE(state, "radio2.begin()");
+
+  state = radio2.setFrequency(receiveFrequency);
+  RADIOLIB_STATE(state, "radio2 setFrequency");
+
+  state = radio2.setOOK(true);
+  RADIOLIB_STATE(state, "radio2 setOOK");
+
+  state = radio2.setCrcFiltering(false);
+  RADIOLIB_STATE(state, "radio2 setCrcFiltering");
+
+  // Same asynchronous-OOK modem setup as the primary channel.
+  radio2.SPIsendCommand(RADIOLIB_CC1101_CMD_IDLE);
+
+  state = radio2.SPIsetRegValue(RADIOLIB_CC1101_REG_PKTLEN, 0);
+  RADIOLIB_STATE(state, "radio2 set PKTLEN");
+
+  state = radio2.SPIsetRegValue(RADIOLIB_CC1101_REG_AGCCTRL2, CC1101_AGCCTRL2);
+  RADIOLIB_STATE(state, "radio2 set AGCCTRL2");
+
+  state = radio2.SPIsetRegValue(RADIOLIB_CC1101_REG_AGCCTRL1, CC1101_AGCCTRL1);
+  RADIOLIB_STATE(state, "radio2 set AGCCTRL1");
+
+  state = radio2.SPIsetRegValue(RADIOLIB_CC1101_REG_AGCCTRL0, CC1101_AGCCTRL0);
+  RADIOLIB_STATE(state, "radio2 set AGCCTRL0");
+
+  state = radio2.SPIsetRegValue(RADIOLIB_CC1101_REG_MDMCFG3, 0x93); // Data rate
+  RADIOLIB_STATE(state, "radio2 set MDMCFG3");
+
+  // Same tuning profile as the primary: RadioLib updates only
+  // MDMCFG4.CHANBW_E/CHANBW_M and preserves the data rate exponent.
+  state = radio2.setRxBandwidth(CC1101_RX_BANDWIDTH);
+  RADIOLIB_STATE(state, "radio2 setRxBandwidth");
+
+  state = radio2.disableSyncWordFiltering(false);
+  RADIOLIB_STATE(state, "radio2 disableSyncWordFiltering");
+
+  state = radio2.receiveDirectAsync();
+  RADIOLIB_STATE(state, "radio2 receiveDirect");
+
+  // RadioLib routes async serial data to GDO0 only; mirror it onto GDO2 so
+  // the board can listen on whichever line RF_MODULE2_RECEIVER_GPIO names.
+  state = radio2.SPIsetRegValue(RADIOLIB_CC1101_REG_IOCFG2, 0x0D);
+  RADIOLIB_STATE(state, "radio2 IOCFG2 serial data out (GDO2)");
+#  if RF_MODULE2_RECEIVER_GPIO != RF_MODULE2_GDO0
+  // Data is consumed on GDO2, so park GDO0 in high impedance (IOCFG 0x2E).
+  // This is not just tidiness: with the demodulator's slicer idling high, a
+  // GDO0 that lands on an ESP32 strap pin (GPIO2, on some boards) holds the
+  // strap high through a reset and blocks serial download mode — the radio
+  // keeps driving the pin because esptool's reset pulse never resets it.
+  radio2.SPIsetRegValue(RADIOLIB_CC1101_REG_IOCFG0, 0x2E);
+#  endif
+  spiGive();
+
+  bool radioFailed = rtl_433_radio_config_failed;
+  rtl_433_radio_config_failed = priorRadioFailure || radioFailed;
+  if (radioFailed) {
+    initializationError = rtl_433_ESPError::RadioInitialization;
+    receiverGpio2 = -1;
+    logprintfLn(LOG_ERR,
+                STR_MODULE " channel 2 disabled: radio configuration failed");
+    return false;
+  }
+
+  logprintfLn(LOG_NOTICE,
+              STR_MODULE " channel 2 receiving on GPIO %d at %.2f MHz",
+              inputPin, receiveFrequency);
+  return true;
+}
+
+/**
+ * @brief Retune the second receive channel. Safe while receiving: capture is
+ * paused for the duration and any in-progress train is discarded.
+ */
+void rtl_433_ESP::setSecondaryFrequency(float receiveFrequency) {
+  if (receiverGpio2 < 0) {
+    logprintfLn(LOG_ERR,
+                STR_MODULE " channel 2 not initialised, cannot retune");
+    return;
+  }
+
+  // Pause channel-2 capture entirely before touching the radio or the
+  // capture state: detach the edge ISR, clear the flag the receiver task
+  // keys on, and give the task time to observe it — the same handshake the
+  // transmit handover uses for the primary channel. Without this the task
+  // can be inside the channel-2 gating block while the state below changes,
+  // and a train captured at the old frequency could be stamped with the new
+  // one.
+  bool wasEnabled = _enabledReceiver2;
+  if (wasEnabled) {
+    _enabledReceiver2 = false;
+    detachInterrupt((uint8_t)receiverGpio2);
+    delay(5); // let rtl_433_ReceiverTask observe the flag
+  }
+
+  spiTake(portMAX_DELAY);
+  radio2.standby();
+  int state = radio2.setFrequency(receiveFrequency);
+  RADIOLIB_STATE(state, "radio2 setFrequency");
+  radio2.receiveDirectAsync();
+  // directMode() rewrites IOCFG0 only; the GDO2 mirror must be re-applied on
+  // every re-entry to direct mode or the data line goes silently dead.
+  radio2.SPIsetRegValue(RADIOLIB_CC1101_REG_IOCFG2, 0x0D);
+#  if RF_MODULE2_RECEIVER_GPIO != RF_MODULE2_GDO0
+  // Re-park GDO0 in high impedance (see initSecondaryReceiver — a strap-pin
+  // GDO0 held high by slicer noise blocks serial download mode).
+  radio2.SPIsetRegValue(RADIOLIB_CC1101_REG_IOCFG0, 0x2E);
+#  endif
+  spiGive();
+
+  // Discard the in-progress capture, if any; already-completed trains carry
+  // their own frequency stamp and may drain through the decoder normally.
+  _freq2Mhz = receiveFrequency;
+  receiveMode2 = false;
+  _nrpulses2 = 0;
+#  if PRETRIGGER_ENABLED
+  _pretriggerCount2 = 0;
+  _pretriggerPendingPulse2 = 0;
+#  endif
+
+  if (wasEnabled) {
+    pinMode(receiverGpio2, INPUT);
+    attachInterrupt((uint8_t)receiverGpio2, interruptHandler2, CHANGE);
+    _enabledReceiver2 = true;
+  }
+  logprintfLn(LOG_NOTICE, STR_MODULE " channel 2 retuned to %.2f MHz",
+              receiveFrequency);
+}
+#endif
 
 /**
  * @brief Is a signal available for decoding ?
@@ -534,9 +809,105 @@ void ICACHE_RAM_ATTR rtl_433_ESP::interruptHandler() {
   }
 }
 
+#ifdef RF_DUAL_CC1101
+/**
+ * @brief Second channel's pulse receiver logic — the primary handler with the
+ * channel-2 state substituted.
+ */
+void ICACHE_RAM_ATTR rtl_433_ESP::interruptHandler2() {
+  if (!_enabledReceiver2) {
+    _noiseCount2++;
+    return;
+  }
+
+  const unsigned long now = micros();
+  const unsigned int duration = now - _lastChange2;
+
+  if (!receiveMode2) {
+#  if PRETRIGGER_ENABLED
+    bool level = digitalRead(receiverGpio2);
+
+    if (_lastChange2 == 0 || duration > PRETRIGGER_WINDOW_US) {
+      _pretriggerCount2 = 0;
+      _pretriggerPendingPulse2 = 0;
+    }
+
+    if (!level) {
+      _pretriggerPendingPulse2 =
+          duration > MINIMUM_PULSE_LENGTH && duration <= PRETRIGGER_WINDOW_US
+              ? duration
+              : 0;
+    } else if (_pretriggerPendingPulse2 > 0 &&
+               duration > MINIMUM_PULSE_LENGTH &&
+               duration <= PRETRIGGER_WINDOW_US) {
+      _pretriggerPulse2[_pretriggerHead2] = _pretriggerPendingPulse2;
+      _pretriggerGap2[_pretriggerHead2] = duration;
+      _pretriggerHead2 = (_pretriggerHead2 + 1) % PRETRIGGER_PAIRS;
+      if (_pretriggerCount2 < PRETRIGGER_PAIRS) {
+        _pretriggerCount2++;
+      }
+      _pretriggerPendingPulse2 = 0;
+    }
+
+    _lastChange2 = now;
+#  endif
+    _noiseCount2++;
+    return;
+  }
+
+  volatile pulse_data_t& pulseTrain = _pulseTrains2[_actualPulseTrain2];
+  volatile int* pulse = pulseTrain.pulse;
+  volatile int* gap = pulseTrain.gap;
+#  ifdef SIGNAL_RSSI
+  volatile int* rssi = pulseTrain.rssi;
+#  endif
+
+  if (duration > MINIMUM_PULSE_LENGTH && currentRssi2 > rssiThreshold2) {
+#  ifdef SIGNAL_RSSI
+    rssi[_nrpulses2] = currentRssi2;
+#  endif
+    if (!digitalRead(receiverGpio2)) {
+      pulse[_nrpulses2] = duration;
+    } else {
+      if (pulse[_nrpulses2] > 0) {
+        gap[_nrpulses2] = duration;
+        _nrpulses2 = (uint16_t)((_nrpulses2 + 1) % PD_MAX_PULSES);
+      } else if (_nrpulses2 > 1) {
+        gap[_nrpulses2 - 1] += duration;
+      } else {
+        gap[_nrpulses2] = duration;
+        _nrpulses2 = (uint16_t)((_nrpulses2 + 1) % PD_MAX_PULSES);
+      }
+    }
+    _lastChange2 = now;
+  }
+}
+
+/**
+ * @brief Copy out the next completed channel-2 pulse train, if any — the
+ * channel-2 counterpart of receivePulseTrain(), sharing captureMux with it.
+ */
+static bool receivePulseTrain2(pulse_data_t* destination) {
+  if (!destination || !_pulseTrains2) {
+    return false;
+  }
+  bool available = false;
+  portENTER_CRITICAL(&captureMux);
+  if (_pulseTrains2[_avaiablePulseTrain2].num_pulses > 0) {
+    uint8_t currentTrain = _avaiablePulseTrain2;
+    memcpy(destination, &_pulseTrains2[currentTrain], sizeof(pulse_data_t));
+    memset(&_pulseTrains2[currentTrain], 0, sizeof(pulse_data_t));
+    _avaiablePulseTrain2 = (_avaiablePulseTrain2 + 1) % RECEIVER_BUFFER_SIZE;
+    available = true;
+  }
+  portEXIT_CRITICAL(&captureMux);
+  return available;
+}
+#endif
+
 /**
  * @brief Reset received signal storage
- * 
+ *
  */
 void rtl_433_ESP::resetReceiver() {
   if (!_pulseTrains) {
@@ -579,30 +950,58 @@ void rtl_433_ESP::enableReceiver() {
     attachInterrupt((uint8_t)receiverGpio, interruptHandler, CHANGE);
     _enabledReceiver = true;
   }
+#ifdef RF_DUAL_CC1101
+  if (receiverGpio2 >= 0) {
+    pinMode(receiverGpio2, INPUT);
+    attachInterrupt((uint8_t)receiverGpio2, interruptHandler2, CHANGE);
+    _enabledReceiver2 = true;
+  }
+#endif
 }
 
 /**
  * @brief Disable receiver logic, and pulse receiver
- * 
+ *
  */
 void rtl_433_ESP::disableReceiver() {
   _enabledReceiver = false;
   if (receiverGpio >= 0) {
     detachInterrupt((uint8_t)receiverGpio);
   }
+#ifdef RF_DUAL_CC1101
+  if (receiverGpio2 >= 0) {
+    _enabledReceiver2 = false;
+    detachInterrupt((uint8_t)receiverGpio2);
+  }
+#endif
 }
 
 void rtl_433_ESP::end() {
   disableReceiver();
   if (rtl_433_ReceiverHandle) {
+    // The receiver task takes the SPI lock around its RSSI reads; deleting
+    // it mid-read would leave the lock held forever and hang the next
+    // blocking SPI operation after a later begin(). Holding the lock across
+    // the deletion means it can only land while the task is outside any
+    // locked section — a task blocked WAITING on the lock is removed from
+    // the semaphore's wait list safely by vTaskDelete.
+    spiTake(portMAX_DELAY);
     vTaskDelete(rtl_433_ReceiverHandle);
     rtl_433_ReceiverHandle = nullptr;
+    spiGive();
   }
   rtlShutdown();
   if (_pulseTrains) {
     free(_pulseTrains);
     _pulseTrains = nullptr;
   }
+#ifdef RF_DUAL_CC1101
+  if (_pulseTrains2) {
+    free(_pulseTrains2);
+    _pulseTrains2 = NULL;
+  }
+  receiverGpio2 = -1;
+#endif
   initialized = false;
   receiverGpio = -1;
 }
@@ -628,6 +1027,29 @@ rtl_433_ESPStatus rtl_433_ESP::statusSnapshot() {
   return snapshot;
 }
 
+#ifdef RF_DUAL_CC1101
+/**
+ * @brief Stop only the primary channel's capture for a transmit handover,
+ * leaving the second channel listening. The receiver task keys each channel
+ * on its own enable flag, so channel 2's RSSI polling and gating continue;
+ * the caller's own radio-register work must run under spiTake()/spiGive().
+ */
+void rtl_433_ESP::suspendPrimaryForTx() {
+  _enabledReceiver = false;
+  if (receiverGpio >= 0) {
+    detachInterrupt((uint8_t)receiverGpio);
+  }
+}
+
+void rtl_433_ESP::resumePrimaryFromTx() {
+  if (receiverGpio >= 0) {
+    pinMode(receiverGpio, INPUT);
+    attachInterrupt((uint8_t)receiverGpio, interruptHandler, CHANGE);
+    _enabledReceiver = true;
+  }
+}
+#endif
+
 /**
  * @brief watch for completed signals being received, and pass to decoder logic
  * 
@@ -639,10 +1061,20 @@ void rtl_433_ESP::loop() {
     if (millis() - _deafWorkaround > 3600000) // restart receiver every hour
     {
       _deafWorkaround = millis();
-      // radio.SetRx(); // set Receive on
-      radio.SPIsendCommand(RADIOLIB_CC1101_CMD_IDLE); // set Receive on
-      radio.SPIsendCommand(RADIOLIB_CC1101_CMD_RX); // set Receive on
-
+      // This runs in the caller's context while the receiver task polls RSSI
+      // on its own core; the strobes must not interleave with those reads.
+      if (spiTake(100)) {
+        // radio.SetRx(); // set Receive on
+        radio.SPIsendCommand(RADIOLIB_CC1101_CMD_IDLE); // set Receive on
+        radio.SPIsendCommand(RADIOLIB_CC1101_CMD_RX); // set Receive on
+#  ifdef RF_DUAL_CC1101
+        if (_enabledReceiver2) {
+          radio2.SPIsendCommand(RADIOLIB_CC1101_CMD_IDLE);
+          radio2.SPIsendCommand(RADIOLIB_CC1101_CMD_RX);
+        }
+#  endif
+        spiGive();
+      }
     } // workaround for a deaf CC1101
 #endif
 
@@ -651,7 +1083,7 @@ void rtl_433_ESP::loop() {
 #ifdef MEMORY_DEBUG
       logprintfLn(LOG_INFO, "Pre copy out of train: %d", ESP.getFreeHeap());
 #endif
-      pulse_data_t* rtl_pulses = (pulse_data_t*)heap_caps_calloc(1, sizeof(pulse_data_t), MALLOC_CAP_INTERNAL);
+      pulse_data_t* rtl_pulses = (pulse_data_t*)heap_caps_calloc(1, sizeof(pulse_data_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
       if (!rtl_pulses) {
         initializationError = rtl_433_ESPError::OutOfMemory;
         droppedDecoderQueue++;
@@ -715,6 +1147,29 @@ void rtl_433_ESP::loop() {
       unparsedSignals = 0;
     }
   }
+
+#ifdef RF_DUAL_CC1101
+  // Channel 2 pickup. Deliberately outside the primary-enabled gate: the
+  // second channel keeps receiving while the primary is suspended for a
+  // transmit handover. totalSignals/ignoredSignals/unparsedSignals remain
+  // whole-device aggregates; messageCount2 is the per-channel counter.
+  if (_enabledReceiver2 && _pulseTrains2 &&
+      _pulseTrains2[_avaiablePulseTrain2].num_pulses > 0) {
+    pulse_data_t* rtl_pulses = (pulse_data_t*)heap_caps_calloc(
+        1, sizeof(pulse_data_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    if (!rtl_pulses) {
+      initializationError = rtl_433_ESPError::OutOfMemory;
+      droppedDecoderQueue++;
+    } else if (!receivePulseTrain2(rtl_pulses)) {
+      free(rtl_pulses);
+    } else if (rtl_pulses->num_pulses > PD_MIN_PULSES) {
+      processSignal(rtl_pulses);
+    } else {
+      ignoredSignals++;
+      free(rtl_pulses);
+    }
+  }
+#endif
   vTaskDelay(1);
 }
 
@@ -728,7 +1183,9 @@ void rtl_433_ESP::rtl_433_ReceiverTask(void* pvParameters) {
     if (_enabledReceiver) {
       // Calculate average RSSI signal level in environment
 
+      spiTake(portMAX_DELAY);
       currentRssi = _getRSSI();
+      spiGive();
       _rssiCount++;
       _totalRssi += currentRssi;
       if (currentRssi > _peakRssi)
@@ -900,6 +1357,8 @@ void rtl_433_ESP::rtl_433_ReceiverTask(void* pvParameters) {
             _pulseTrains[_actualPulseTrain].signalDuration =
                 signalEnd - signalStart;
             _pulseTrains[_actualPulseTrain].signalRssi = signalRssi;
+            _pulseTrains[_actualPulseTrain].centerfreq_hz =
+                receiveFrequencyMhz * 1.0e6f;
 #ifdef DEMOD_DEBUG
             logprintf(LOG_INFO, "Signal length: %lu",
                       _pulseTrains[_actualPulseTrain].signalDuration);
@@ -943,6 +1402,165 @@ void rtl_433_ESP::rtl_433_ReceiverTask(void* pvParameters) {
         }
       }
     }
+
+#ifdef RF_DUAL_CC1101
+    // Channel 2: the same RSSI-gated capture logic against the second radio.
+    // Interleaved in this task on purpose — one context owns all RSSI polling,
+    // so the two radios' SPI transfers can never interleave with each other.
+    if (_enabledReceiver2) {
+      spiTake(portMAX_DELAY);
+      currentRssi2 = radio2.getRSSI();
+      spiGive();
+      _rssiCount2++;
+      _totalRssi2 += currentRssi2;
+      if (currentRssi2 > _peakRssi2)
+        _peakRssi2 = currentRssi2;
+      if (currentRssi2 > rssiThreshold2)
+        _aboveThreshold2++;
+
+#  ifdef AUTORSSITHRESHOLD
+      int rssiSamples2 = _rssiCalibrated2 ? RSSI_SAMPLES : RSSI_INITIAL_SAMPLES;
+#  else
+      int rssiSamples2 = RSSI_SAMPLES;
+#  endif
+
+      if (_rssiCount2 >= rssiSamples2) {
+        averageRssi2 = _totalRssi2 / _rssiCount2;
+#  ifdef AUTORSSITHRESHOLD
+        rssiThreshold2 = averageRssi2 + rssiThresholdDelta;
+        if (!_rssiCalibrated2) {
+          _rssiCalibrated2 = true;
+          logprintfLn(LOG_NOTICE,
+                      "Channel 2 initial RSSI calibration complete: average %d "
+                      "dbm, threshold %d dbm, samples %d, peak %d dbm, "
+                      "above-threshold %d; reception enabled",
+                      averageRssi2, rssiThreshold2, rssiSamples2, _peakRssi2,
+                      _aboveThreshold2);
+        } else {
+          logprintfLn(LOG_DEBUG,
+                      "Channel 2 average RSSI Signal %d dbm, adjusted RSSI "
+                      "Threshold %d, samples %d, peak %d dbm, "
+                      "above-threshold %d",
+                      averageRssi2, rssiThreshold2, rssiSamples2, _peakRssi2,
+                      _aboveThreshold2);
+        }
+#  endif
+        _peakRssi2 = -256;
+        _aboveThreshold2 = 0;
+        _totalRssi2 = 0;
+        _rssiCount2 = 0;
+      }
+
+#  ifdef AUTORSSITHRESHOLD
+      if (!_rssiCalibrated2) {
+        vTaskDelay(1);
+        continue;
+      }
+#  endif
+
+      if (currentRssi2 > rssiThreshold2) // A signal is present
+      {
+        if (!receiveMode2) {
+          receiveMode2 = true;
+          signalStart2 = micros();
+          signalRssi2 = currentRssi2;
+
+#  if PRETRIGGER_ENABLED
+          noInterrupts();
+          uint8_t selected = 0;
+          unsigned int pretriggerDuration = 0;
+          for (uint8_t i = 0; i < _pretriggerCount2; ++i) {
+            uint8_t index =
+                (_pretriggerHead2 + PRETRIGGER_PAIRS - 1 - i) %
+                PRETRIGGER_PAIRS;
+            unsigned int pairDuration =
+                _pretriggerPulse2[index] + _pretriggerGap2[index];
+            if (pretriggerDuration + pairDuration > PRETRIGGER_WINDOW_US) {
+              break;
+            }
+            pretriggerDuration += pairDuration;
+            selected++;
+          }
+
+          uint8_t first =
+              (_pretriggerHead2 + PRETRIGGER_PAIRS - selected) %
+              PRETRIGGER_PAIRS;
+          for (uint8_t i = 0; i < selected; ++i) {
+            uint8_t index = (first + i) % PRETRIGGER_PAIRS;
+            _pulseTrains2[_actualPulseTrain2].pulse[i] =
+                _pretriggerPulse2[index];
+            _pulseTrains2[_actualPulseTrain2].gap[i] = _pretriggerGap2[index];
+#    ifdef SIGNAL_RSSI
+            _pulseTrains2[_actualPulseTrain2].rssi[i] = currentRssi2;
+#    endif
+          }
+          _nrpulses2 = selected;
+
+          if (!digitalRead(receiverGpio2) &&
+              _pretriggerPendingPulse2 > 0 &&
+              _nrpulses2 < PD_MAX_PULSES) {
+            _pulseTrains2[_actualPulseTrain2].pulse[_nrpulses2] =
+                _pretriggerPendingPulse2;
+            pretriggerDuration += _pretriggerPendingPulse2;
+          }
+
+          _pretriggerCount2 = 0;
+          _pretriggerPendingPulse2 = 0;
+          interrupts();
+
+          signalStart2 -= pretriggerDuration;
+#  else
+          _lastChange2 = signalStart2;
+#  endif
+
+          if (_noiseCount2 > 100) {
+            _noiseCount2 = 0;
+          }
+        }
+        signalEnd2 = micros();
+      } else if (micros() - signalEnd2 < MINIMUM_SIGNAL_LENGTH &&
+                 micros() - signalStart2 > 30000) {
+        // skip over signal drop outs
+      } else // A signal is not present
+      {
+        if (receiveMode2) // Complete reception of a signal
+        {
+          receiveMode2 = false;
+          totalSignals++;
+          if (rtl_433_capture::isCompleteSignal(
+                  _nrpulses2, signalEnd2 - signalStart2, PD_MIN_PULSES,
+                  MINIMUM_SIGNAL_LENGTH)) {
+            uint8_t nextTrain2 =
+                (_actualPulseTrain2 + 1) % RECEIVER_BUFFER_SIZE;
+            portENTER_CRITICAL(&captureMux);
+            if (!rtl_433_capture::canPublishToNextBuffer(
+                    _pulseTrains2[nextTrain2].num_pulses)) {
+              memset(&_pulseTrains2[_actualPulseTrain2], 0,
+                     sizeof(pulse_data_t));
+              droppedCaptureBuffers++;
+              portEXIT_CRITICAL(&captureMux);
+              _nrpulses2 = 0;
+            } else {
+              _pulseTrains2[_actualPulseTrain2].num_pulses = _nrpulses2 + 1;
+              _pulseTrains2[_actualPulseTrain2].signalDuration =
+                  signalEnd2 - signalStart2;
+              _pulseTrains2[_actualPulseTrain2].signalRssi = signalRssi2;
+              _pulseTrains2[_actualPulseTrain2].centerfreq_hz =
+                  _freq2Mhz * 1.0e6f;
+              messageCount2++;
+              gapStart2 = micros();
+              _actualPulseTrain2 = nextTrain2;
+              portEXIT_CRITICAL(&captureMux);
+              _nrpulses2 = 0;
+            }
+          } else {
+            ignoredSignals++;
+            _nrpulses2 = 0;
+          }
+        }
+      }
+    }
+#endif
     vTaskDelay(1);
   }
 }
@@ -1080,6 +1698,19 @@ void rtl_433_ESP::getStatus() {
                 "_enabledReceiver", "", DATA_INT, _enabledReceiver,
                 "receiveMode",    "", DATA_INT, receiveMode,
                 NULL);
+
+#ifdef RF_DUAL_CC1101
+  data_append(data,
+              "RTLCnt2", "", DATA_INT, messageCount2,
+              "RTLRssi2", "", DATA_INT, currentRssi2,
+              "RTLAVGRssi2", "", DATA_INT, averageRssi2,
+              "RTLRssiThresh2", "", DATA_INT, rssiThreshold2,
+              // rounded to 10 kHz so 433.92f doesn't serialise as 433.9199829
+              "mhz2", "", DATA_DOUBLE,
+              (double)((long)(_freq2Mhz * 100.0f + 0.5f)) / 100.0,
+              "_enabledReceiver2", "", DATA_INT, (int)_enabledReceiver2,
+              NULL);
+#endif
 #ifdef RF_MODULE_INIT_STATUS
   getModuleStatus();
 #endif
@@ -1113,6 +1744,9 @@ int rtl_433_ESP::_getRSSI(void) {
  *
  */
 void rtl_433_ESP::getModuleStatus() {
+  // Register dump runs in the caller's context while the receiver task may be
+  // polling RSSI on its own core; hold the SPI lock for the duration.
+  spiTake(portMAX_DELAY);
 #ifdef RF_CC1101
   alogprintfLn(LOG_INFO, "----- CC1101 Status -----");
   alogprintfLn(LOG_INFO, "CC1101_MDMCFG1: 0x%.2x",
@@ -1270,6 +1904,7 @@ void rtl_433_ESP::getModuleStatus() {
   alogprintfLn(LOG_INFO, "----- SX127x Status -----");
 
 #endif
+  spiGive();
 }
 
 /**

--- a/src/rtl_433_ESP.h
+++ b/src/rtl_433_ESP.h
@@ -220,8 +220,10 @@
 #endif
 
 #ifdef RF_CC1101
-#  define RF_MODULE_RECEIVER_GPIO RF_MODULE_GDO0
-#  define STR_MODULE              "CC1101"
+#  ifndef RF_MODULE_RECEIVER_GPIO
+#    define RF_MODULE_RECEIVER_GPIO RF_MODULE_GDO0
+#  endif
+#  define STR_MODULE "CC1101"
 #  ifndef RF_MODULE_CS
 #    define RF_MODULE_CS SS
 #  endif
@@ -232,6 +234,32 @@
 #  else
 #    define RADIO_LIB_MODULE \
       new Module(RF_MODULE_CS, RF_MODULE_GDO0, RADIOLIB_NC, RF_MODULE_GDO2)
+#  endif
+
+/*
+ * Optional second CC1101 sharing the primary radio's SPI bus. The
+ * second radio is receive-only and shares the pulse decoder: its captured
+ * trains carry centerfreq_hz so a decode can be attributed to the radio (and
+ * frequency) it came from. Enable by defining RF_MODULE2_CS and
+ * RF_MODULE2_GDO0; the data input the ESP32 listens on defaults to GDO0 and
+ * can be moved with RF_MODULE2_RECEIVER_GPIO (the async serial bitstream is
+ * mirrored onto GDO2 as well).
+ */
+#  if defined(RF_MODULE2_CS) && defined(RF_MODULE2_GDO0)
+#    if !(defined(RF_MODULE_SCK) && defined(RF_MODULE_MISO) && \
+          defined(RF_MODULE_MOSI) && defined(RF_MODULE_CS))
+#      error "RF_MODULE2_* needs the shared-SPI RF_MODULE_SCK/MISO/MOSI/CS pin set"
+#    endif
+#    define RF_DUAL_CC1101
+#    ifndef RF_MODULE2_GDO2
+#      define RF_MODULE2_GDO2 RADIOLIB_NC
+#    endif
+#    ifndef RF_MODULE2_RECEIVER_GPIO
+#      define RF_MODULE2_RECEIVER_GPIO RF_MODULE2_GDO0
+#    endif
+#    define RADIO_LIB_MODULE2                                 \
+      new Module(RF_MODULE2_CS, RF_MODULE2_GDO0, RADIOLIB_NC, \
+                 RF_MODULE2_GDO2, newSPI)
 #  endif
 #endif
 
@@ -361,6 +389,60 @@ public:
   static rtl_433_ESPStatus statusSnapshot();
 
   /**
+   * Frequency the primary receiver is tuned to, in MHz. Set by
+   * initReceiver(); a caller that retunes the radio behind the library's back
+   * (e.g. a transmit/receive handover) must keep it current, because every
+   * captured pulse train is stamped with it (pulse_data_t.centerfreq_hz) and
+   * the stamp is what attributes a decode to a frequency.
+   */
+  static float receiveFrequencyMhz;
+
+  /**
+   * Serialise access to the SPI bus shared by the radio(s). The receiver task
+   * polls RSSI over SPI from its own core; any other context touching a radio
+   * register must hold this lock. Returns false if the lock could not be
+   * taken within waitMs. Both are safe to call before initReceiver().
+   */
+  static bool spiTake(uint32_t waitMs);
+  static void spiGive();
+
+#ifdef RF_DUAL_CC1101
+  /**
+   * Initialise the second CC1101 as an additional receive channel. Call after
+   * initReceiver() (the shared SPI bus and the receiver task must exist).
+   *
+   * inputPin         - GPIO carrying the second radio's demodulated bitstream
+   * receiveFrequency - receive frequency in MHz
+   *
+   * Returns false — and leaves the channel disabled, with lastError() set —
+   * if the pulse-train buffers cannot be allocated or the radio rejects its
+   * configuration. The primary channel is unaffected either way.
+   */
+  static bool initSecondaryReceiver(byte inputPin, float receiveFrequency);
+
+  /**
+   * Retune the second receive channel. Safe while receiving: capture is
+   * paused for the duration and any in-progress train is discarded.
+   */
+  static void setSecondaryFrequency(float receiveFrequency);
+
+  /**
+   * Stop only the primary channel's capture (ISR + RSSI polling) for a
+   * transmit handover on the primary radio, leaving the second channel
+   * listening. resumePrimaryFromTx() restores capture; putting the primary
+   * radio itself back into receive mode remains the caller's job.
+   */
+  static void suspendPrimaryForTx();
+  static void resumePrimaryFromTx();
+
+  static int messageCount2;
+  static int currentRssi2;
+  static int signalRssi2;
+  static int rssiThreshold2;
+  static int averageRssi2;
+#endif
+
+  /**
    * Enable pulse receiver interrupt and logic
    */
   static void enableReceiver();
@@ -485,6 +567,13 @@ private:
    * InterruptChain)
    */
   static void interruptHandler();
+
+#ifdef RF_DUAL_CC1101
+  /**
+   * Edge handler for the second receive channel's data input.
+   */
+  static void interruptHandler2();
+#endif
 
   /**
    * interruptHandler used to calibrate OOK floor threshold


### PR DESCRIPTION
Two CC1101s on one SPI bus can receive simultaneously (e.g. 433.92 + 915 MHz). RF_MODULE2_* defines add a second RadioLib instance with its own ISR, RSSI gating and buffers, feeding the shared decoder; decodes carry an "mhz" field naming the channel. Includes an SPI lock so one radio can transmit while the other keeps receiving, a MALLOC_CAP_8BIT fix for pulse buffers (IRAM LoadStoreError), and CC1101_DATA_ON_GDO2 for boards that read the bitstream on GDO2.